### PR TITLE
Disable cloning for process objects

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -202,6 +202,7 @@ NULL
 
 process <- R6Class(
   "process",
+  cloneable = FALSE,
   public = list(
 
     initialize = function(command = NULL, args = character(),


### PR DESCRIPTION
Cloning a process object would only cause problems, so this PR disables it.