### PR TITLE
IO improvements

### DIFF
--- a/R/initialize.R
+++ b/R/initialize.R
@@ -50,10 +50,10 @@ process_initialize <- function(self, private, command, args,
   private$windows_hide_window <- windows_hide_window
 
   if (isTRUE(stdout)) {
-    private$cleanfiles <- c(private$cleanfiles, stdout <- tempfile())
+    private$cleanfiles <- c(private$cleanfiles, stdout <- tempfile("process-stdout-"))
   }
   if (isTRUE(stderr)) {
-    private$cleanfiles <- c(private$cleanfiles, stderr <- tempfile())
+    private$cleanfiles <- c(private$cleanfiles, stderr <- tempfile("process-stderr-"))
   }
 
   if (is.null(command)) {

--- a/R/io.R
+++ b/R/io.R
@@ -1,11 +1,33 @@
 
 process_get_output_connection <- function(self, private) {
   "!DEBUG process_get_output_connection `private$get_short_name()`"
+
+  # First time accessing connection when the output is a file (not pipe)
+  if (is.null(private$stdout_pipe) &&
+      !is.null(private$stdout) &&
+      file.exists(private$stdout))
+  {
+    private$stdout_pipe <- file(private$stdout)
+
+    # Need explicit open. Otherwise, each call to (e.g.) readLines() will open
+    # and close the file. Use "rb" mode so that readChar() will preserve "\r\n"
+    # on Windows.
+    open(private$stdout_pipe, open = "rb")
+  }
+
   private$stdout_pipe
 }
 
 process_get_error_connection <- function(self, private) {
   "!DEBUG process_get_error_connection `private$get_short_name()`"
+  if (is.null(private$stderr_pipe) &&
+      !is.null(private$stderr) &&
+      file.exists(private$stderr))
+  {
+    private$stderr_pipe <- file(private$stderr)
+    open(private$stderr_pipe, open = "rb")
+  }
+
   private$stderr_pipe
 }
 
@@ -19,32 +41,44 @@ process_read_error_lines <- function(self, private, ...) {
   readLines(process_get_error_connection(self, private), ...)
 }
 
-process_is_incompelete_output <- function(self, private) {
+process_is_incomplete_output <- function(self, private) {
   isIncomplete(process_get_output_connection(self, private))
 }
 
-process_is_incompelete_error <- function(self, private) {
+process_is_incomplete_error <- function(self, private) {
   isIncomplete(process_get_error_connection(self, private))
 }
 
 process_read_all_output <- function(self, private) {
   self$wait()
+
   con <- self$get_output_connection()
-  result <- ""
-  while (self$is_incomplete_output()) {
-    self$poll_io(-1)
-    result <- paste0(result, readChar(con, 1024))
+  if (private$stdout == "|") {
+    result <- ""
+    while (self$is_incomplete_output()) {
+      self$poll_io(-1)
+      result <- paste0(result, readChar(con, 1024))
+    }
+  }
+  else {
+    result <- read_char_all(con)
   }
   result
 }
 
 process_read_all_error <- function(self, private) {
   self$wait()
+
   con <- self$get_error_connection()
-  result <- ""
-  while (self$is_incomplete_error()) {
-    self$poll_io(-1)
-    result <- paste0(result, readChar(con, 1024))
+  if (private$stderr == "|") {
+    result <- ""
+    while (self$is_incomplete_error()) {
+      self$poll_io(-1)
+      result <- paste0(result, readChar(con, 1024))
+    }
+  }
+  else {
+    result <- read_char_all(con)
   }
   result
 }
@@ -52,9 +86,14 @@ process_read_all_error <- function(self, private) {
 process_read_all_output_lines <- function(self, private, ...) {
   self$wait()
   results <- character()
-  while (self$is_incomplete_output()) {
-    self$poll_io(-1)
-    results <- c(results, self$read_output_lines(...))
+  if (private$stdout == "|") {
+    while (self$is_incomplete_output()) {
+      self$poll_io(-1)
+      results <- c(results, self$read_output_lines(...))
+    }
+  }
+  else {
+    results <- readLines(self$get_output_connection())
   }
   results
 }
@@ -62,11 +101,44 @@ process_read_all_output_lines <- function(self, private, ...) {
 process_read_all_error_lines <- function(self, private, ...) {
   self$wait()
   results <- character()
-  while (self$is_incomplete_error()) {
-    self$poll_io(-1)
-    results <- c(results, self$read_error_lines(...))
+  if (private$stderr == "|") {
+    while (self$is_incomplete_error()) {
+      self$poll_io(-1)
+      results <- c(results, self$read_error_lines(...))
+    }
+  }
+  else {
+    results <- readLines(self$get_error_connection())
   }
   results
+}
+
+# Read all characters from a file or connection object and return it as a
+# string.
+read_char_all<- function(con) {
+  if (is.character(con)) {
+    # If it's a filename, simply read in the entire file in one go.
+    result <- readChar(con, file.info(con)$size, useBytes = TRUE)
+  }
+  else if (inherits(con, "connection")) {
+    # If it's a connection object, keep reading until no more is left.
+    results <- character(0)
+
+    # Read in reasonably sized blocks of text. Don't use useBytes=T, because it
+    # could stop in the middle of a multi-byte character.
+    txt <- readChar(con, nchars = 65536)
+    while (length(txt) > 0) {
+      results <- c(results, txt)
+      txt <- readChar(con, nchars = 65536)
+    }
+
+    result <- paste(results, collapse = "")
+  }
+  else {
+    stop("Don't know how to read from object of class ", class(con))
+  }
+
+  result
 }
 
 poll_codes <- c("nopipe", "ready", "timeout", "closed", "silent")

--- a/R/process.R
+++ b/R/process.R
@@ -267,10 +267,10 @@ process <- R6Class(
       process_read_error_lines(self, private, ...),
 
     is_incomplete_output = function()
-      process_is_incompelete_output(self, private),
+      process_is_incomplete_output(self, private),
 
     is_incomplete_error = function()
-      process_is_incompelete_error(self, private),
+      process_is_incomplete_error(self, private),
 
     get_output_connection = function()
       process_get_output_connection(self, private),

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -3,20 +3,58 @@ context("io")
 
 test_that("We can get the output", {
 
-  win  <- "dir /b /A"
-  unix <- "ls -A"
+  cmd     <- if (os_type() == "windows") "dir /b /A" else "ls -A"
+  newline <- if (os_type() == "windows") "\r\n" else "\n"
+  all_files <- sort(dir(no..=TRUE, all.files=TRUE))
 
-  p <- process$new(
-    commandline = if (os_type() == "windows") win else unix,
-    stdout = "|", stderr = "|"
-  )
-  on.exit(try_silently(p$kill(grace = 0)), add = TRUE)
+  p1 <- process$new(commandline = cmd, stdout = "|", stderr = "|")$wait()
+  on.exit(try_silently(p1$kill(grace = 0)), add = TRUE)
+  out <- sort(p1$read_all_output_lines())
+  expect_identical(out, all_files)
 
-  out <- sort(p$read_all_output_lines())
-  expect_identical(sort(out), sort(dir(no..=TRUE, all.files=TRUE)))
+  # read_output_lines and read_all_output_lines don't repeat content
+  p2 <- process$new(commandline = cmd, stdout = "|", stderr = "|")$wait()
+  on.exit(try_silently(p2$kill(grace = 0)), add = TRUE)
+  expect_identical(sort(p2$read_output_lines(n = 1)), all_files[1])
+  expect_identical(sort(p2$read_all_output_lines()), all_files[-1])
+  expect_identical(sort(p2$read_all_output_lines()), character(0))
+
+  # read_all_output returns a string
+  p3 <- process$new(commandline = cmd, stdout = "|", stderr = "|")$wait()
+  on.exit(try_silently(p3$kill(grace = 0)), add = TRUE)
+  out <- strsplit(p3$read_all_output(), newline)[[1]]
+  out <- sort(out)
+  expect_identical(out, all_files)
+  # Subsequent calls return "". (Should it be character(0)?)
+  expect_identical(p3$read_all_output(), "")
+
+
+  # ==== Same tests as above, but with file output instead of pipes ====
+  p4 <- process$new(commandline = cmd)$wait()
+  on.exit(try_silently(p4$kill(grace = 0)), add = TRUE)
+  out <- sort(p4$read_all_output_lines())
+  expect_identical(out, all_files)
+
+  # read_output_lines and read_all_output_lines don't repeat content
+  p5 <- process$new(commandline = cmd)$wait()
+  on.exit(try_silently(p5$kill(grace = 0)), add = TRUE)
+  expect_identical(sort(p5$read_output_lines(n = 1)), all_files[1])
+  expect_identical(sort(p5$read_all_output_lines()), all_files[-1])
+  expect_identical(sort(p5$read_all_output_lines()), character(0))
+
+  # read_all_output returns a string
+  p6 <- process$new(commandline = cmd)$wait()
+  on.exit(try_silently(p6$kill(grace = 0)), add = TRUE)
+  out <- strsplit(p6$read_all_output(), newline)[[1]]
+  out <- sort(out)
+  expect_identical(out, all_files)
+  # Subsequent calls return "". (Should it be character(0)?)
+  expect_identical(p6$read_all_output(), "")
 })
 
 test_that("We can get the error stream", {
+
+  newline <- if (os_type() == "windows") "\r\n" else "\n"
 
   tmp <- tempfile(fileext = ".bat")
   on.exit(unlink(tmp), add = TRUE)
@@ -24,11 +62,43 @@ test_that("We can get the error stream", {
   cat(">&2 echo hello", ">&2 echo world", sep = "\n", file = tmp)
   Sys.chmod(tmp, "700")
 
-  p <- process$new(tmp, stderr = "|")
-  on.exit(try_silently(p$kill(grace = 0)), add = TRUE)
+  p1 <- process$new(tmp, stderr = "|")$wait()
+  on.exit(try_silently(p1$kill(grace = 0)), add = TRUE)
+  expect_identical(p1$read_all_error_lines(), c("hello", "world"))
 
-  out <- sort(p$read_all_error_lines())
-  expect_identical(out, c("hello", "world"))
+  # read_error_lines and read_all_error_lines don't repeat content
+  p2 <- process$new(tmp, stderr = "|")$wait()
+  on.exit(try_silently(p2$kill(grace = 0)), add = TRUE)
+  expect_identical(p2$read_error_lines(n = 1), "hello")
+  expect_identical(p2$read_all_error_lines(), "world")
+  expect_identical(p2$read_all_error_lines(), character(0))
+
+  # read_all_error returns a string
+  p3 <- process$new(tmp, stderr = "|")$wait()
+  on.exit(try_silently(p3$kill(grace = 0)), add = TRUE)
+  expect_identical(p3$read_all_error(), paste0("hello", newline, "world", newline))
+  # Subsequent calls return ""
+  expect_identical(p3$read_all_error(), "")
+
+
+  # ==== Same tests as above, but with file output instead of pipes ====
+  p4 <- process$new(tmp)$wait()
+  on.exit(try_silently(p4$kill(grace = 0)), add = TRUE)
+  expect_identical(p4$read_all_error_lines(), c("hello", "world"))
+
+  # read_error_lines and read_all_error_lines don't repeat content
+  p5 <- process$new(tmp)$wait()
+  on.exit(try_silently(p5$kill(grace = 0)), add = TRUE)
+  expect_identical(p5$read_error_lines(n = 1), "hello")
+  expect_identical(p5$read_all_error_lines(), "world")
+  expect_identical(p5$read_all_error_lines(), character(0))
+
+  # read_all_error returns a string
+  p6 <- process$new(tmp)$wait()
+  on.exit(try_silently(p6$kill(grace = 0)), add = TRUE)
+  expect_identical(p6$read_all_error(), paste0("hello", newline, "world", newline))
+  # Subsequent calls return ""
+  expect_identical(p6$read_all_error(), "")
 })
 
 test_that("Output & error at the same time", {


### PR DESCRIPTION
This PR fixes #61, and properly supports writing stdout and stderr to files.

Things that still need to be addressed:

- [ ] If a process writes stdout to a file (the default) and you call `$get_all_output_lines()`, and then it is GC'd, R issues a warning about closing an unused connection. I tried to close the connection in a finalizer, but the warning happens in the GC before the finalizer is executed.
    ```R
    p <- processx::process$new(commandline = 'ls -A')
    p$read_all_output_lines()
    rm(p); gc()
    # Warning message:
    # In .Internal(gc(verbose, reset)) :
    #   closing unused connection 3 (/var/folders/vd/0_g4hj6d7kq_fw5gd_r0ml5w0000gn/T//RtmpYCeB4d/process-stdout-df16218f8674)
    ```
- [ ] `is_incomplete_output()` and `_error()` don't work correctly for file output, and I suspect it's not possible to make them work.
- [ ] The poll tests expect the status of stdout or stderr to be `"nopipe"` when the default settings are used (the default is to use temp files), but instead it is now `"closed"`. I think the correct status should be `"ready"`, but I'm not completely sure.
- [ ] By default, stdout and stderr are written to temp files. Should it be changed so that they're discarded, or maybe write them to the R console like `system2` does by default?