### PR TITLE
I/O improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 2.0.1
+Version: 2.0.1.9000
 Author: Gábor Csárdi
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Tools to run system processes in the background.

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -24,8 +24,8 @@ process_initialize <- function(self, private, command, args,
 
   assert_that(is_string_or_null(command))
   assert_that(is.character(args))
-  assert_that(is_flag_or_string(stdout))
-  assert_that(is_flag_or_string(stderr))
+  assert_that(is_string_or_null(stdout))
+  assert_that(is_string_or_null(stderr))
   assert_that(is_string_or_null(commandline))
   assert_that(is_flag(cleanup))
   assert_that(is_flag(echo_cmd))
@@ -49,13 +49,6 @@ process_initialize <- function(self, private, command, args,
   private$windows_verbatim_args <- windows_verbatim_args
   private$windows_hide_window <- windows_hide_window
 
-  if (isTRUE(stdout)) {
-    private$cleanfiles <- c(private$cleanfiles, stdout <- tempfile())
-  }
-  if (isTRUE(stderr)) {
-    private$cleanfiles <- c(private$cleanfiles, stderr <- tempfile())
-  }
-
   if (is.null(command)) {
     if (os_type() == "unix") {
       command <- "sh"
@@ -72,8 +65,6 @@ process_initialize <- function(self, private, command, args,
   }
 
   "!DEBUG process_initialize exec()"
-  if (isFALSE(stdout)) stdout <- NULL
-  if (isFALSE(stderr)) stderr <- NULL
   private$status <- .Call(
     c_processx_exec,
     command, c(command, args), stdout, stderr,

--- a/R/io.R
+++ b/R/io.R
@@ -1,11 +1,15 @@
 
 process_get_output_connection <- function(self, private) {
   "!DEBUG process_get_output_connection `private$get_short_name()`"
+  if (is.null(private$stdout_pipe))
+    stop("stdout is not a pipe.")
   private$stdout_pipe
 }
 
 process_get_error_connection <- function(self, private) {
   "!DEBUG process_get_error_connection `private$get_short_name()`"
+  if (is.null(private$stderr_pipe))
+    stop("stderr is not a pipe.")
   private$stderr_pipe
 }
 

--- a/R/io.R
+++ b/R/io.R
@@ -1,14 +1,23 @@
+process_has_output_connection <- function(self, private) {
+  "!DEBUG process_has_output_connection `private$get_short_name()`"
+  !is.null(private$stdout_pipe)
+}
+
+process_has_error_connection <- function(self, private) {
+  "!DEBUG process_has_error_connection `private$get_short_name()`"
+  !is.null(private$stderr_pipe)
+}
 
 process_get_output_connection <- function(self, private) {
   "!DEBUG process_get_output_connection `private$get_short_name()`"
-  if (is.null(private$stdout_pipe))
+  if (!self$has_output_connection())
     stop("stdout is not a pipe.")
   private$stdout_pipe
 }
 
 process_get_error_connection <- function(self, private) {
   "!DEBUG process_get_error_connection `private$get_short_name()`"
-  if (is.null(private$stderr_pipe))
+  if (!self$has_error_connection())
     stop("stderr is not a pipe.")
   private$stderr_pipe
 }

--- a/R/poll.R
+++ b/R/poll.R
@@ -81,8 +81,18 @@ poll <- function(processes, ms) {
   statuses <- lapply(processes, function(p) {
     p$.__enclos_env__$private$status
   })
-  std_outs <- lapply(processes, function(p) p$get_output_connection())
-  std_errs <- lapply(processes, function(p) p$get_error_connection())
+  std_outs <- lapply(processes, function(p) {
+    if (p$has_output_connection())
+      p$get_output_connection()
+    else
+      NULL
+  })
+  std_errs <- lapply(processes, function(p) {
+    if (p$has_error_connection())
+      p$get_error_connection()
+    else
+      NULL
+  })
 
   res <- lapply(
     .Call(c_processx_poll, statuses, as.integer(ms), std_outs, std_errs),

--- a/R/poll.R
+++ b/R/poll.R
@@ -19,10 +19,11 @@
 #'
 #' @section Known issues:
 #'
-#' You cannot wait on the termination of a process directly. It is only
-#' signalled through the closed stdout and stderr pipes. This means that
-#' if both stdout and stderr are ignored or closed for a process, then you
-#' will not be notified when it exits.
+#' `poll()` cannot wait on the termination of a process directly. It is
+#' only signalled through the closed stdout and stderr pipes. This means
+#' that if both stdout and stderr are ignored or closed for a process,
+#' then you will not be notified when it exits. If you want to wait for
+#' just a single process to end, it can be done with the `$wait()` method.
 #'
 #' @param processes A list of `process` objects to wait on. If this is a
 #'   named list, then the returned list will have the same names. This

--- a/R/process.R
+++ b/R/process.R
@@ -12,7 +12,7 @@ NULL
 #'
 #' @section Usage:
 #' \preformatted{p <- process$new(command = NULL, args, commandline = NULL,
-#'                  stdout = TRUE, stderr = TRUE, cleanup = TRUE,
+#'                  stdout = NULL, stderr = NULL, cleanup = TRUE,
 #'                  echo_cmd = FALSE, supervise = FALSE,
 #'                  windows_verbatim_args = FALSE, windows_hide_window = FALSE)
 #'
@@ -57,13 +57,11 @@ NULL
 #'     \code{cmd /c <commandline>}. If you want more control, then call
 #'     your chosen shell directly.}
 #'   \item{stdout}{What to do with the standard output. Possible values:
-#'     \code{FALSE}: discard it; a string, redirect it to this file,
-#'     \code{TRUE}: redirect it to a temporary file, \code{"|"}: create an
-#'     R connection for it.}
+#'     \code{NULL}: discard it; a string, redirect it to this file,
+#'     \code{"|"}: create an R connection for it.}
 #'   \item{stderr}{What to do with the standard error. Possible values:
-#'     \code{FALSE}: discard it; a string, redirect it to this file,
-#'     \code{TRUE}: redirect it to a temporary file, \code{"|"}: create an
-#'     R connection for it.}
+#'     \code{NULL}: discard it; a string, redirect it to this file,
+#'     \code{"|"}: create an R connection for it.}
 #'   \item{cleanup}{Whether to kill the process (and its children)
 #'     if the \code{process} object is garbage collected.}
 #'   \item{echo_cmd}{Whether to print the command to the screen before
@@ -131,7 +129,9 @@ NULL
 #'
 #' \code{$read_output_lines()} reads from standard output connection of
 #' the process. If the standard output connection was not requested, then
-#' then it returns an error. It uses a non-blocking text connection.
+#' then it returns an error. It uses a non-blocking text connection. This
+#' will work only if `stdout="|"` was used. Otherwise, it will throw an
+#' error.
 #'
 #' \code{$read_error_lines()} is similar to \code{$read_output_lines}, but
 #' it reads from the standard error stream.
@@ -154,25 +154,29 @@ NULL
 #' It does not return until the process has finished.
 #' Note that this process involves waiting for the process to finish,
 #' polling for I/O and potentically several `readLines()` calls.
-#' It returns a character scalar.
+#' It returns a character scalar. This will return content only if
+#' `stdout="|"` was used. Otherwise, it will throw an error.
 #'
 #' \code{$read_all_error()} waits for all standard error from the process.
 #' It does not return until the process has finished.
 #' Note that this process involves waiting for the process to finish,
 #' polling for I/O and potentically several `readLines()` calls.
-#' It returns a character scalar.
+#' It returns a character scalar. This will return content only if
+#' `stderr="|"` was used. Otherwise, it will throw an error.
 #'
 #' \code{$read_all_output_lines()} waits for all standard output lines
 #' from a process. It does not return until the process has finished.
 #' Note that this process involves waiting for the process to finish,
 #' polling for I/O and potentically several `readLines()` calls.
-#' It returns a character vector.
+#' It returns a character vector. This will return content only if
+#' `stdout="|"` was used. Otherwise, it will throw an error.
 #'
 #' \code{$read_all_error_lines()} waits for all standard error lines from
 #' a process. It does not return until the process has finished.
 #' Note that this process involves waiting for the process to finish,
 #' polling for I/O and potentically several `readLines()` calls.
-#' It returns a character vector.
+#' It returns a character vector. This will return content only if
+#' `stderr="|"` was used. Otherwise, it will throw an error.
 #'
 #' \code{$poll_io()} polls the process's connections for I/O. See more in
 #' the \emph{Polling} section, and see also the \code{\link{poll}} function
@@ -218,7 +222,7 @@ process <- R6Class(
   public = list(
 
     initialize = function(command = NULL, args = character(),
-      commandline = NULL, stdout = TRUE, stderr = TRUE, cleanup = TRUE,
+      commandline = NULL, stdout = NULL, stderr = NULL, cleanup = TRUE,
       echo_cmd = FALSE, supervise = FALSE, windows_verbatim_args = FALSE,
       windows_hide_window = FALSE)
       process_initialize(self, private, command, args, commandline,

--- a/R/process.R
+++ b/R/process.R
@@ -136,6 +136,14 @@ NULL
 #' \code{$read_error_lines()} is similar to \code{$read_output_lines}, but
 #' it reads from the standard error stream.
 #'
+#' \code{$has_output_connection()} returns `TRUE` if there is a connection
+#' object for standard output; in other words, if `stdout="|"`. It returns
+#' `FALSE` otherwise.
+#'
+#' \code{$has_error_connection()} returns `TRUE` if there is a connection
+#' object for standard error; in other words, if `stderr="|"`. It returns
+#' `FALSE` otherwise.
+#'
 #' \code{$get_output_connection()} returns a connection object, to the
 #' standard output stream of the process.
 #'
@@ -275,6 +283,12 @@ process <- R6Class(
 
     is_incomplete_error = function()
       process_is_incompelete_error(self, private),
+
+    has_output_connection = function()
+      process_has_output_connection(self, private),
+
+    has_error_connection = function()
+      process_has_error_connection(self, private),
 
     get_output_connection = function()
       process_get_output_connection(self, private),

--- a/man/poll.Rd
+++ b/man/poll.Rd
@@ -46,10 +46,11 @@ connection was.
 \section{Known issues}{
 
 
-You cannot wait on the termination of a process directly. It is only
-signalled through the closed stdout and stderr pipes. This means that
-if both stdout and stderr are ignored or closed for a process, then you
-will not be notified when it exits.
+\code{poll()} cannot wait on the termination of a process directly. It is
+only signalled through the closed stdout and stderr pipes. This means
+that if both stdout and stderr are ignored or closed for a process,
+then you will not be notified when it exits. If you want to wait for
+just a single process to end, it can be done with the \code{$wait()} method.
 }
 
 \examples{

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -141,6 +141,14 @@ error.
 \code{$read_error_lines()} is similar to \code{$read_output_lines}, but
 it reads from the standard error stream.
 
+\code{$has_output_connection()} returns \code{TRUE} if there is a connection
+object for standard output; in other words, if \code{stdout="|"}. It returns
+\code{FALSE} otherwise.
+
+\code{$has_error_connection()} returns \code{TRUE} if there is a connection
+object for standard error; in other words, if \code{stderr="|"}. It returns
+\code{FALSE} otherwise.
+
 \code{$get_output_connection()} returns a connection object, to the
 standard output stream of the process.
 

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -13,7 +13,7 @@ streams. The process id is then used to manage the process.
 \section{Usage}{
 
 \preformatted{p <- process$new(command = NULL, args, commandline = NULL,
-                 stdout = TRUE, stderr = TRUE, cleanup = TRUE,
+                 stdout = NULL, stderr = NULL, cleanup = TRUE,
                  echo_cmd = FALSE, supervise = FALSE,
                  windows_verbatim_args = FALSE, windows_hide_window = FALSE)
 
@@ -60,13 +60,11 @@ On Windows it uses the \code{cmd} shell:
 \code{cmd /c <commandline>}. If you want more control, then call
 your chosen shell directly.}
 \item{stdout}{What to do with the standard output. Possible values:
-\code{FALSE}: discard it; a string, redirect it to this file,
-\code{TRUE}: redirect it to a temporary file, \code{"|"}: create an
-R connection for it.}
+\code{NULL}: discard it; a string, redirect it to this file,
+\code{"|"}: create an R connection for it.}
 \item{stderr}{What to do with the standard error. Possible values:
-\code{FALSE}: discard it; a string, redirect it to this file,
-\code{TRUE}: redirect it to a temporary file, \code{"|"}: create an
-R connection for it.}
+\code{NULL}: discard it; a string, redirect it to this file,
+\code{"|"}: create an R connection for it.}
 \item{cleanup}{Whether to kill the process (and its children)
 if the \code{process} object is garbage collected.}
 \item{echo_cmd}{Whether to print the command to the screen before
@@ -136,7 +134,9 @@ still be killed when the object is garbage collected.
 
 \code{$read_output_lines()} reads from standard output connection of
 the process. If the standard output connection was not requested, then
-then it returns an error. It uses a non-blocking text connection.
+then it returns an error. It uses a non-blocking text connection. This
+will work only if \code{stdout="|"} was used. Otherwise, it will throw an
+error.
 
 \code{$read_error_lines()} is similar to \code{$read_output_lines}, but
 it reads from the standard error stream.
@@ -159,25 +159,29 @@ process exited). It return \code{TRUE} otherwise.
 It does not return until the process has finished.
 Note that this process involves waiting for the process to finish,
 polling for I/O and potentically several \code{readLines()} calls.
-It returns a character scalar.
+It returns a character scalar. This will return content only if
+\code{stdout="|"} was used. Otherwise, it will throw an error.
 
 \code{$read_all_error()} waits for all standard error from the process.
 It does not return until the process has finished.
 Note that this process involves waiting for the process to finish,
 polling for I/O and potentically several \code{readLines()} calls.
-It returns a character scalar.
+It returns a character scalar. This will return content only if
+\code{stderr="|"} was used. Otherwise, it will throw an error.
 
 \code{$read_all_output_lines()} waits for all standard output lines
 from a process. It does not return until the process has finished.
 Note that this process involves waiting for the process to finish,
 polling for I/O and potentically several \code{readLines()} calls.
-It returns a character vector.
+It returns a character vector. This will return content only if
+\code{stdout="|"} was used. Otherwise, it will throw an error.
 
 \code{$read_all_error_lines()} waits for all standard error lines from
 a process. It does not return until the process has finished.
 Note that this process involves waiting for the process to finish,
 polling for I/O and potentically several \code{readLines()} calls.
-It returns a character vector.
+It returns a character vector. This will return content only if
+\code{stderr="|"} was used. Otherwise, it will throw an error.
 
 \code{$poll_io()} polls the process's connections for I/O. See more in
 the \emph{Polling} section, and see also the \code{\link{poll}} function

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -1,15 +1,26 @@
 
 context("io")
 
+test_that("Output and error are discarded by default", {
+
+  cmd <- if (os_type() == "windows") "dir /b /A" else "ls -A"
+
+  p <- process$new(commandline = cmd)
+  on.exit(try_silently(p$kill(grace = 0)), add = TRUE)
+
+  expect_error(p$read_output_lines(n=1),  "not a pipe")
+  expect_error(p$read_all_output_lines(), "not a pipe")
+  expect_error(p$read_all_output(),       "not a pipe")
+  expect_error(p$read_error_lines(n=1),   "not a pipe")
+  expect_error(p$read_all_error_lines(),  "not a pipe")
+  expect_error(p$read_all_error(),        "not a pipe")
+})
+
 test_that("We can get the output", {
 
-  win  <- "dir /b /A"
-  unix <- "ls -A"
+  cmd <- if (os_type() == "windows") "dir /b /A" else "ls -A"
 
-  p <- process$new(
-    commandline = if (os_type() == "windows") win else unix,
-    stdout = "|", stderr = "|"
-  )
+  p <- process$new(commandline = cmd, stdout = "|", stderr = "|")
   on.exit(try_silently(p$kill(grace = 0)), add = TRUE)
 
   out <- sort(p$read_all_output_lines())


### PR DESCRIPTION
This does the following:
* `stdout` and `stderr` no longer accept the values `TRUE` and `FALSE`. The value `NULL` now means to discard the output, and is the default.
* If `read_all_output()`, `read_output_lines()`, or `read_all_output_lines()` is called when the stdout is `NULL` or a file, it throws an error with a more informative message than before. Same for stderr.

I also added a small fix to the `poll()` documentation.