### PR TITLE
Add get_output_file and get_error_file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 2.0.1.9000
+Version: 2.0.1.9001
 Author: Gábor Csárdi
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Tools to run system processes in the background.

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -73,6 +73,11 @@ process_initialize <- function(self, private, command, args,
   )
   private$starttime <- Sys.time()
 
+  if (is.character(stdout) && stdout != "|")
+    stdout <- full_path(stdout)
+  if (is.character(stderr) && stderr != "|")
+    stderr <- full_path(stderr)
+
   ## Store the output and error files, we'll open them later if needed
   private$stdout <- stdout
   private$stderr <- stderr

--- a/R/io.R
+++ b/R/io.R
@@ -82,6 +82,14 @@ process_read_all_error_lines <- function(self, private, ...) {
   results
 }
 
+process_get_output_file <- function(self, private) {
+  private$stdout
+}
+
+process_get_error_file <- function(self, private) {
+  private$stderr
+}
+
 poll_codes <- c("nopipe", "ready", "timeout", "closed", "silent")
 
 process_poll_io <- function(self, private, ms) {

--- a/R/process.R
+++ b/R/process.R
@@ -186,6 +186,12 @@ NULL
 #' It returns a character vector. This will return content only if
 #' `stderr="|"` was used. Otherwise, it will throw an error.
 #'
+#' \code{$get_output_file()} returns the value of the `stdout` argument
+#' provided when the process object was created.
+#'
+#' \code{$get_error_file()} returns the value of the `stderr` argument
+#' provided when the process object was created.
+#'
 #' \code{$poll_io()} polls the process's connections for I/O. See more in
 #' the \emph{Polling} section, and see also the \code{\link{poll}} function
 #' to poll on multiple processes.
@@ -307,6 +313,12 @@ process <- R6Class(
 
     read_all_error_lines = function(...)
       process_read_all_error_lines(self, private, ...),
+
+    get_output_file = function()
+      process_get_output_file(self, private),
+
+    get_error_file = function()
+      process_get_error_file(self, private),
 
     poll_io = function(timeout)
       process_poll_io(self, private, timeout)

--- a/R/process.R
+++ b/R/process.R
@@ -186,11 +186,13 @@ NULL
 #' It returns a character vector. This will return content only if
 #' `stderr="|"` was used. Otherwise, it will throw an error.
 #'
-#' \code{$get_output_file()} returns the value of the `stdout` argument
-#' provided when the process object was created.
+#' \code{$get_output_file()} if the `stdout` argument was a filename,
+#' this returns the absolute path to the file. If `stdout` was `"|"` or
+#' `NULL`, this simply returns that value.
 #'
-#' \code{$get_error_file()} returns the value of the `stderr` argument
-#' provided when the process object was created.
+#' \code{$get_error_file()} if the `stderr` argument was a filename,
+#' this returns the absolute path to the file. If `stderr` was `"|"` or
+#' `NULL`, this simply returns that value.
 #'
 #' \code{$poll_io()} polls the process's connections for I/O. See more in
 #' the \emph{Polling} section, and see also the \code{\link{poll}} function

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,3 +25,57 @@ last_char <- function(x) {
   nc <- nchar(x)
   substring(x, nc, nc)
 }
+
+# Given a filename, return full path to that file. On Windows, this includes the
+# drive. It currently doesn't handle Windows network paths (start with "//").
+# Also, only "/" is allowed (no backslashes in the path).
+full_path <- function(path) {
+  # Try expanding "~"
+  path <- path.expand(path)
+
+  # If relative path, prepend current dir. On Windows, also record current
+  # drive.
+  if (is_windows()) {
+    if (grepl("^[a-zA-Z]:/", path)) {
+      drive <- substring(path, 1, 2)
+      path <- substring(path, 3)
+    } else {
+      drive <- substring(getwd(), 1, 2)
+
+      if (substr(path, 1, 1) != "/")
+        path <- substring(file.path(getwd(), path), 3)
+    }
+  } else {
+    if (substr(path, 1, 1) != "/")
+      path <- file.path(getwd(), path)
+  }
+
+  parts <- strsplit(path, "/")[[1]]
+
+  # Collapse any ".." and "." in path.
+  i <- 2
+  while (i <= length(parts)) {
+    if (parts[i] == ".") {
+      parts <- parts[-i]
+
+    } else if (parts[i] == "..") {
+      if (i == 2) {
+        parts <- parts[-i]
+      } else {
+        parts <- parts[-c(i-1, i)]
+        i <- i-1
+      }
+    } else {
+      i <- i+1
+    }
+  }
+
+  new_path <- paste(parts, collapse = "/")
+  if (new_path == "")
+    new_path <- "/"
+
+  if (is_windows())
+    new_path <- paste0(drive, new_path)
+
+  new_path
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,25 +26,44 @@ last_char <- function(x) {
   substring(x, nc, nc)
 }
 
-# Given a filename, return full path to that file. On Windows, this includes the
-# drive. It currently doesn't handle Windows network paths (start with "//").
-# Also, only "/" is allowed (no backslashes in the path).
+# Given a filename, return an absolute path to that file. This has two important
+# differences from normalizePath(). (1) The file does not need to exist, and (2)
+# the path is merely absolute, whereas normalizePath() returns a canonical path,
+# which resolves symbolic links, gives canonical case, and, on Windows, may give
+# short names.
+#
+# On Windows, the returned path includes the drive ("C:") or network server
+# ("//myserver"). Only "/" is supported as a path separator (no backslashes).
 full_path <- function(path) {
+  assert_that(is_string(path))
+
   # Try expanding "~"
   path <- path.expand(path)
 
   # If relative path, prepend current dir. On Windows, also record current
   # drive.
   if (is_windows()) {
-    if (grepl("^[a-zA-Z]:/", path)) {
+    if (grepl("^[a-zA-Z]:", path)) {
       drive <- substring(path, 1, 2)
       path <- substring(path, 3)
+
+    } else if (substring(path, 1, 2) == "//") {
+      # Extract server name, like "//server", and use as drive.
+      pos <- regexec("^(//[^/]*)(.*)", path)[[1]]
+      drive <- substring(path, pos[2], attr(pos, "match.length", exact = TRUE)[2])
+      path <- substring(path, pos[3])
+
+      # Must have a name, like "//server"
+      if (drive == "//")
+        stop("Server name not found in network path.")
+
     } else {
       drive <- substring(getwd(), 1, 2)
 
       if (substr(path, 1, 1) != "/")
         path <- substring(file.path(getwd(), path), 3)
     }
+
   } else {
     if (substr(path, 1, 1) != "/")
       path <- file.path(getwd(), path)
@@ -52,10 +71,10 @@ full_path <- function(path) {
 
   parts <- strsplit(path, "/")[[1]]
 
-  # Collapse any ".." and "." in path.
+  # Collapse any "..", ".", and "" in path.
   i <- 2
   while (i <= length(parts)) {
-    if (parts[i] == ".") {
+    if (parts[i] == "." || parts[i] == "") {
       parts <- parts[-i]
 
     } else if (parts[i] == "..") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ last_char <- function(x) {
 # short names.
 #
 # On Windows, the returned path includes the drive ("C:") or network server
-# ("//myserver"). Only "/" is supported as a path separator (no backslashes).
+# ("//myserver").
 full_path <- function(path) {
   assert_that(is_string(path))
 
@@ -43,6 +43,8 @@ full_path <- function(path) {
   # If relative path, prepend current dir. On Windows, also record current
   # drive.
   if (is_windows()) {
+    path <- gsub("\\", "/", path, fixed = TRUE)
+
     if (grepl("^[a-zA-Z]:", path)) {
       drive <- substring(path, 1, 2)
       path <- substring(path, 3)

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -191,6 +191,12 @@ polling for I/O and potentically several \code{readLines()} calls.
 It returns a character vector. This will return content only if
 \code{stderr="|"} was used. Otherwise, it will throw an error.
 
+\code{$get_output_file()} returns the value of the \code{stdout} argument
+provided when the process object was created.
+
+\code{$get_error_file()} returns the value of the \code{stderr} argument
+provided when the process object was created.
+
 \code{$poll_io()} polls the process's connections for I/O. See more in
 the \emph{Polling} section, and see also the \code{\link{poll}} function
 to poll on multiple processes.

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -191,11 +191,13 @@ polling for I/O and potentically several \code{readLines()} calls.
 It returns a character vector. This will return content only if
 \code{stderr="|"} was used. Otherwise, it will throw an error.
 
-\code{$get_output_file()} returns the value of the \code{stdout} argument
-provided when the process object was created.
+\code{$get_output_file()} if the \code{stdout} argument was a filename,
+this returns the absolute path to the file. If \code{stdout} was \code{"|"} or
+\code{NULL}, this simply returns that value.
 
-\code{$get_error_file()} returns the value of the \code{stderr} argument
-provided when the process object was created.
+\code{$get_error_file()} if the \code{stderr} argument was a filename,
+this returns the absolute path to the file. If \code{stderr} was \code{"|"} or
+\code{NULL}, this simply returns that value.
 
 \code{$poll_io()} polls the process's connections for I/O. See more in
 the \emph{Polling} section, and see also the \code{\link{poll}} function

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -30,6 +30,13 @@ test_that("full_path gives correct values", {
 test_that("full_path gives correct values, windows", {
   skip_other_platforms("windows")
 
+  # Backslash separators
+  expect_identical(full_path("f:\\a/b"), "f:/a/b")
+  expect_identical(full_path("a\\b"), file.path(getwd(), "a/b"))
+  expect_identical(full_path("a\\\\b"), file.path(getwd(), "a/b"))
+  expect_identical(full_path("\\\\a\\b"), "//a/b")
+  expect_identical(full_path("\\\\a/b/..\\c"), "//a/c")
+
   # Drives
   expect_identical(full_path("f:/a/b"), "f:/a/b")
   expect_identical(full_path("f:/a/b/../../.."), "f:/")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -21,7 +21,11 @@ test_that("full_path gives correct values", {
   expect_identical(full_path("/a/./b/../c"), file.path(drive, "a/c"))
 
   expect_identical(full_path("~nonexistent_user"), file.path(getwd(), "~nonexistent_user"))
-  expect_identical(full_path("~/a/../b"), path.expand("~/b"))
+  expect_identical(
+    full_path("~/a/../b"),
+    # On Windows, path.expand() can return a path with backslashes
+    gsub("\\", "/", path.expand("~/b"), fixed = TRUE)
+  )
 
   expect_identical(full_path("a//b"), file.path(getwd(), "a/b"))
   expect_identical(full_path("/a//b"), file.path(drive, "a/b"))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -8,24 +8,53 @@ test_that("full_path gives correct values", {
     # Use "" so that file.path("", "a") will return "/a"
     drive <- ""
   }
+
   expect_identical(full_path("/a/b"), file.path(drive, "a/b"))
   expect_identical(full_path("/a/b/"), file.path(drive, "a/b"))
-  expect_identical(full_path("/"), paste0(drive, "/"))
+  expect_identical(full_path("/"), file.path(drive, ""))
   expect_identical(full_path("a"), file.path(getwd(), "a"))
   expect_identical(full_path("a/b"), file.path(getwd(), "a/b"))
+
   expect_identical(full_path("a/../b/c"), file.path(getwd(), "b/c"))
   expect_identical(full_path("../../../../../../../../../../../a"), file.path(drive, "a"))
   expect_identical(full_path("/../.././a"), file.path(drive, "a"))
   expect_identical(full_path("/a/./b/../c"), file.path(drive, "a/c"))
+
   expect_identical(full_path("~nonexistent_user"), file.path(getwd(), "~nonexistent_user"))
   expect_identical(full_path("~/a/../b"), path.expand("~/b"))
+
+  expect_identical(full_path("a//b"), file.path(getwd(), "a/b"))
+  expect_identical(full_path("/a//b"), file.path(drive, "a/b"))
 })
 
 test_that("full_path gives correct values, windows", {
   skip_other_platforms("windows")
 
+  # Drives
   expect_identical(full_path("f:/a/b"), "f:/a/b")
   expect_identical(full_path("f:/a/b/../../.."), "f:/")
   expect_identical(full_path("f:/../a"), "f:/a")
   expect_identical(full_path("f:/"), "f:/")
+  expect_identical(full_path("f:"), "f:/")
+
+  # Leading double slashes. Server name always has trailing slash ("//server/"),
+  # like drives do ("f:/"). But dirs on the server don't have a trailing slash.
+  expect_identical(full_path("//a"), "//a/")
+  expect_identical(full_path("//a/"), "//a/")
+  expect_identical(full_path("//a/b"), "//a/b")
+  expect_identical(full_path("//a/b/.."), "//a/")
+  # Can't go .. to remove the server name
+  expect_identical(full_path("//a/b/../.."), "//a/")
+  expect_identical(full_path("//a/../b"), "//a/b")
+  expect_error(full_path("//"))
+  expect_error(full_path("///"))
+  expect_error(full_path("///a"))
+})
+
+test_that("full_path gives correct values, unix", {
+  skip_other_platforms("unix")
+
+  # Leading double slashes should collapse
+  expect_identical(full_path("//"), "/")
+  expect_identical(full_path("///a/"), "/a")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,31 @@
+context("utils")
+
+test_that("full_path gives correct values", {
+  if (is_windows()) {
+    # Will be something like "C:"
+    drive <- substring(getwd(), 1, 2)
+  } else {
+    # Use "" so that file.path("", "a") will return "/a"
+    drive <- ""
+  }
+  expect_identical(full_path("/a/b"), file.path(drive, "a/b"))
+  expect_identical(full_path("/a/b/"), file.path(drive, "a/b"))
+  expect_identical(full_path("/"), paste0(drive, "/"))
+  expect_identical(full_path("a"), file.path(getwd(), "a"))
+  expect_identical(full_path("a/b"), file.path(getwd(), "a/b"))
+  expect_identical(full_path("a/../b/c"), file.path(getwd(), "b/c"))
+  expect_identical(full_path("../../../../../../../../../../../a"), file.path(drive, "a"))
+  expect_identical(full_path("/../.././a"), file.path(drive, "a"))
+  expect_identical(full_path("/a/./b/../c"), file.path(drive, "a/c"))
+  expect_identical(full_path("~nonexistent_user"), file.path(getwd(), "~nonexistent_user"))
+  expect_identical(full_path("~/a/../b"), path.expand("~/b"))
+})
+
+test_that("full_path gives correct values, windows", {
+  skip_other_platforms("windows")
+
+  expect_identical(full_path("f:/a/b"), "f:/a/b")
+  expect_identical(full_path("f:/a/b/../../.."), "f:/")
+  expect_identical(full_path("f:/../a"), "f:/a")
+  expect_identical(full_path("f:/"), "f:/")
+})


### PR DESCRIPTION
This adds methods `get_output_file()` and `get_error_file()`.

I also implemented a function called `full_path()` that returns the full path to a file. Sort of like `normalizePath()`, but it doesn't follow symlinks, and it works even if the file does not exist.
