### PR TITLE
Round milliseconds. Fixes #85

### DIFF
--- a/R/supervisor.R
+++ b/R/supervisor.R
@@ -98,7 +98,7 @@ supervisor_start <- function() {
   cur_time <- Sys.time()
   end_time <- cur_time + 5
   while (cur_time < end_time) {
-    p$poll_io(as.numeric(end_time - cur_time, units = "secs") * 1000)
+    p$poll_io(round(as.numeric(end_time - cur_time, units = "secs") * 1000))
 
     if (!p$is_alive())
       break

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,7 @@
 
+* Fixed a bug where `process$new(supervisor=TRUE)` could give the error
+  message `Error: ms is not a length 1 integer` (@wch).
+
 # 3.0.0
 
 * `$kill()` kills the complete child-tree of the process.


### PR DESCRIPTION
This fixes #85.

The problem happens when `as.numeric(end_time - cur_time, units = "secs") * 1000 ` is not a whole number.

For example, in my testing, it can have a value like `4996.067`.