### PR TITLE
Fixed typo in `Running an external process`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -92,7 +92,7 @@ px <- paste0(
 px
 ```
 
-### Runing an external process
+### Running an external process
 
 The `run()` function runs an external command. It requires a single command,
 and a character vector of arguments. You don't need to quote the command


### PR DESCRIPTION
One `n` was missing from `Running an external process`.