### PR TITLE
Use IOCP on Windows

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,9 @@
 
 # 3.0.3.9000
 
+* Allow polling more than 64 connections on Windows, by using IOCP
+  instead of `WaitForMultipleObjects()`, #81, #106
+
 * Fix a race condition on Windows, when creating named pipes for stdout
   or stderr. The client sometimes didn't wait for the server, and processx
   failed with ERROR_PIPE_BUSY (231, All pipe instances are busy).

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 OBJECTS = test-connections.o init.o poll.o processx-connection.o     \
           processx-vector.o                                          \
           win/processx.o win/stdio.o win/named_pipe.o win/cleanup.o  \
-	  test-runner.o
+	  win/iocp.o test-runner.o
 
 .PHONY: all clean
 

--- a/src/poll.c
+++ b/src/poll.c
@@ -15,7 +15,9 @@ SEXP processx_poll(SEXP statuses, SEXP ms) {
     SEXP status = VECTOR_ELT(statuses, i);
     processx_handle_t *handle = R_ExternalPtrAddr(status);
     processx_c_pollable_from_connection(&pollables[i*2], handle->pipes[1]);
+    if (handle->pipes[1]) handle->pipes[1]->poll_idx = i * 2;
     processx_c_pollable_from_connection(&pollables[i*2+1], handle->pipes[2]);
+    if (handle->pipes[2]) handle->pipes[2]->poll_idx = i * 2 + 1;
     SET_VECTOR_ELT(result, i, allocVector(INTSXP, 2));
   }
 

--- a/src/processx-connection.c
+++ b/src/processx-connection.c
@@ -210,6 +210,16 @@ processx_connection_t *processx_c_connection_create(
     PROCESSX_ERROR("Cannot create connection event", GetLastError());
     return 0; 			/* never reached */
   }
+
+  HANDLE iocp = processx__get_default_iocp();
+  HANDLE res = CreateIoCompletionPort(
+    /* FileHandle =  */                con->handle.handle,
+    /* ExistingCompletionPort = */     iocp,
+    /* CompletionKey = */              (ULONG_PTR) con,
+    /* NumberOfConcurrentThreads = */  0);
+
+  if (!res) PROCESSX_ERROR("cannot add file to IOCP", GetLastError());
+
 #else
   con->handle = os_handle;
 #endif
@@ -340,7 +350,10 @@ int processx_c_connection_is_eof(processx_connection_t *ccon) {
 /* Close */
 void processx_c_connection_close(processx_connection_t *ccon) {
 #ifdef _WIN32
-  if (ccon->handle.handle) CloseHandle(ccon->handle.handle);
+  if (ccon->handle.handle) {
+    CancelIo(ccon->handle.handle);
+    CloseHandle(ccon->handle.handle);
+  }
   ccon->handle.handle = 0;
   if (ccon->handle.overlapped.hEvent) {
     CloseHandle(ccon->handle.overlapped.hEvent);
@@ -364,13 +377,14 @@ int processx_c_connection_poll(processx_pollable_t pollables[],
 
   int hasdata = 0;
   size_t i, j = 0;
-  HANDLE *handles;
   int *ptr;
-  DWORD waitres;
   int timeleft = timeout;
+  HANDLE iocp = processx__get_default_iocp();
+  DWORD bytes;
+  OVERLAPPED *overlapped = 0;
+  ULONG_PTR key;
 
   ptr = (int*) R_alloc(npollables, sizeof(int));
-  handles = (HANDLE*) R_alloc(npollables, sizeof(HANDLE));
 
   for (i = 0; i < npollables; i++) {
     processx_pollable_t *el = pollables + i;
@@ -382,7 +396,6 @@ int processx_c_connection_poll(processx_pollable_t pollables[],
     } else if (el->event == PXREADY) {
       hasdata++;
     } else if (el->event == PXSILENT && handle != 0) {
-      handles[j] = handle;
       ptr[j] = i;
       j++;
     } else {
@@ -394,40 +407,56 @@ int processx_c_connection_poll(processx_pollable_t pollables[],
 
   if (hasdata) timeout = timeleft = 0;
 
-  waitres = WAIT_TIMEOUT;
-  while (timeout < 0 || timeleft > PROCESSX_INTERRUPT_INTERVAL) {
-    waitres = WaitForMultipleObjects(
-      j,
-      handles,
-      /* bWaitAll = */ FALSE,
-      PROCESSX_INTERRUPT_INTERVAL);
-    if (waitres != WAIT_TIMEOUT) break;
+  while (timeout < 0 || timeleft >= 0) {
+    int poll_timeout;
+    if (timeout < 0 || timeleft > PROCESSX_INTERRUPT_INTERVAL) {
+      poll_timeout = PROCESSX_INTERRUPT_INTERVAL;
+    } else {
+      poll_timeout = timeleft;
+    }
+
+    GetQueuedCompletionStatus(
+      /* CompletionPort  = */ iocp,
+      /* lpNumberOfBytes = */ &bytes,
+      /* lpCompletionKey = */ &key,
+      /* lpOverlapped    = */ &overlapped,
+      /* dwMilliseconds  = */ poll_timeout);
+
+    if (overlapped) {
+      /* data */
+      processx_connection_t *con = (processx_connection_t*) key;
+      int poll_idx = con->poll_idx;
+      con->handle.read_pending = FALSE;
+      con->buffer_data_size += bytes;
+      if (con->buffer_data_size > 0) processx__connection_to_utf8(con);
+      if (con->type == PROCESSX_FILE_TYPE_ASYNCFILE) {
+	/* TODO: larget files */
+	con->handle.overlapped.Offset += bytes;
+      }
+
+      if (!bytes) {
+	con->is_eof_raw_ = 1;
+	if (con->utf8_data_size == 0 && con->buffer_data_size == 0) {
+	  con->is_eof_ = 1;
+	}
+      }
+
+      if (pollables[poll_idx].object == con) {
+	pollables[poll_idx].event = PXREADY;
+	hasdata++;
+	break;
+      }
+
+    } else if (GetLastError() != WAIT_TIMEOUT) {
+      PROCESSX_ERROR("Cannot poll", GetLastError());
+    }
 
     R_CheckUserInterrupt();
     timeleft -= PROCESSX_INTERRUPT_INTERVAL;
   }
 
-  /* Maybe some time left from the timeout */
-  if (waitres == WAIT_TIMEOUT && timeleft > 0) {
-    waitres = WaitForMultipleObjects(
-      j,
-      handles,
-      /* bWaitAll = */ FALSE,
-      timeleft);
-  }
-
-  if (waitres == WAIT_FAILED) {
-    PROCESSX_ERROR("waiting in poll", GetLastError());
-
-  } else if (waitres == WAIT_TIMEOUT) {
-    if (hasdata == 0) {
-      for (i = 0; i < j; i++) pollables[ptr[i]].event = PXTIMEOUT;
-    }
-
-  } else {
-    int ready = waitres - WAIT_OBJECT_0;
-    pollables[ptr[ready]].event = PXREADY;
-    hasdata++;
+  if (hasdata == 0) {
+    for (i = 0; i < j; i++) pollables[ptr[i]].event = PXTIMEOUT;
   }
 
   return hasdata;
@@ -539,8 +568,9 @@ void processx__connection_start_read(processx_connection_t *ccon) {
     if (err == ERROR_BROKEN_PIPE || err == ERROR_HANDLE_EOF) {
       ccon->is_eof_raw_ = 1;
       if (ccon->utf8_data_size == 0 && ccon->buffer_data_size == 0) {
-	ccon->is_eof_ = 1;
+        ccon->is_eof_ = 1;
       }
+      if (ccon->buffer_data_size) processx__connection_to_utf8(ccon);
     } else if (err == ERROR_IO_PENDING) {
       ccon->handle.read_pending = TRUE;
     } else {
@@ -548,13 +578,9 @@ void processx__connection_start_read(processx_connection_t *ccon) {
       PROCESSX_ERROR("reading from connection", err);
     }
   } else {
-    /* Returned synchronously. */
-    ccon->handle.read_pending = FALSE;
-    ccon->buffer_data_size += bytes_read;
-    if (ccon->type == PROCESSX_FILE_TYPE_ASYNCFILE) {
-      /* TODO: large files */
-      ccon->handle.overlapped.Offset += bytes_read;
-    }
+    /* Returned synchronously, but the event will be still signalled,
+       so we just drop the sync data for now. */
+    ccon->handle.read_pending  = TRUE;
   }
 }
 
@@ -598,7 +624,7 @@ int processx_i_poll_func_connection(
   PROCESSX__I_POLL_FUNC_CONNECTION_READY;
 
 #ifdef _WIN32
-  processx__connection_read(ccon);
+  processx__connection_start_read(ccon);
   /* Starting to read may actually get some data, or an EOF, so check again */
   PROCESSX__I_POLL_FUNC_CONNECTION_READY;
   if (handle) *handle = ccon->handle.overlapped.hEvent;
@@ -803,7 +829,6 @@ static void processx__connection_realloc(processx_connection_t *ccon) {
 
 static ssize_t processx__connection_read(processx_connection_t *ccon) {
   DWORD todo, bytes_read = 0;
-  BOOLEAN result;
 
   /* Nothing to read, nothing to convert to UTF8 */
   if (ccon->is_eof_raw_ && ccon->buffer_data_size == 0) {
@@ -822,45 +847,49 @@ static ssize_t processx__connection_read(processx_connection_t *ccon) {
 
   /* A read might be pending at this point. See if it has finished. */
   if (ccon->handle.read_pending) {
-    result = GetOverlappedResult(
-      /* hFile = */                      &ccon->handle.handle,
-      /* lpOverlapped = */               &ccon->handle.overlapped,
-      /* lpNumberOfBytesTransferred = */ &bytes_read,
-      /* bWait = */                      FALSE);
+    HANDLE iocp = processx__get_default_iocp();
+    ULONG_PTR key;
+    DWORD bytes;
+    OVERLAPPED *overlapped = 0;
 
-    if (!result) {
-      DWORD err = GetLastError();
-      if (err == ERROR_BROKEN_PIPE || err == ERROR_HANDLE_EOF) {
-	ccon->handle.read_pending = FALSE;
-	ccon->is_eof_raw_ = 1;
-	if (ccon->utf8_data_size == 0 && ccon->buffer_data_size == 0) {
-	  ccon->is_eof_ = 1;
+    while (1) {
+      GetQueuedCompletionStatus(
+        /* CompletionPort  = */ iocp,
+	/* lpNumberOfBytes = */ &bytes,
+	/* lpCompletionKey = */ &key,
+	/* lpOverlapped    = */ &overlapped,
+	/* dwMilliseconds  = */ 0);
+
+      if (overlapped) {
+	processx_connection_t *con = (processx_connection_t *) key;
+	con->handle.read_pending = FALSE;
+	con->buffer_data_size += bytes;
+	if (con->buffer && con->buffer_data_size > 0) {
+	  bytes = processx__connection_to_utf8(con);
 	}
-	bytes_read = 0;
+	if (con->type == PROCESSX_FILE_TYPE_ASYNCFILE) {
+	  /* TODO: large files */
+	  con->handle.overlapped.Offset += bytes;
+	}
+	if (!bytes) {
+	  con->is_eof_raw_ = 1;
+	  if (con->utf8_data_size == 0 && con->buffer_data_size == 0) {
+	    con->is_eof_ = 1;
+	  }
+	}
 
-      } else if (err == ERROR_IO_INCOMPLETE) {
+	if (con == ccon) {
+	  bytes_read = bytes;
+	  break;
+	}
+
+      } else if (GetLastError() != WAIT_TIMEOUT) {
+	PROCESSX_ERROR("Read error", GetLastError());
 
       } else {
-	ccon->handle.read_pending = FALSE;
-	PROCESSX_ERROR("getting overlapped result in connection read", err);
-	return 0;			/* never called */
-      }
-
-    } else {
-      ccon->handle.read_pending = FALSE;
-      ccon->buffer_data_size += bytes_read;
-      if (ccon->type == PROCESSX_FILE_TYPE_ASYNCFILE) {
-	/* TODO: large files */
-	ccon->handle.overlapped.Offset += bytes_read;
+	break;
       }
     }
-  }
-
-  /* If there is anything to convert to UTF8, try converting */
-  if (ccon->buffer_data_size > 0) {
-    bytes_read = processx__connection_to_utf8(ccon);
-  } else {
-    bytes_read = 0;
   }
 
   return bytes_read;

--- a/src/processx-connection.c
+++ b/src/processx-connection.c
@@ -441,7 +441,8 @@ int processx_c_connection_poll(processx_pollable_t pollables[],
 	}
       }
 
-      if (pollables[poll_idx].object == con) {
+      if (poll_idx < npollables &&
+	  pollables[poll_idx].object == con) {
 	pollables[poll_idx].event = PXREADY;
 	hasdata++;
 	break;

--- a/src/processx-connection.h
+++ b/src/processx-connection.h
@@ -55,6 +55,7 @@ typedef struct processx_connection_s {
   size_t utf8_allocated_size;
   size_t utf8_data_size;
 
+  int poll_idx;
 } processx_connection_t;
 
 /* Generic poll method
@@ -173,6 +174,11 @@ int processx_c_pollable_from_connection(
 
 #ifndef _WIN32
 typedef unsigned long DWORD;
+#endif
+
+#ifdef _WIN32
+extern HANDLE processx__connection_iocp;
+HANDLE processx__get_default_iocp();
 #endif
 
 #define PROCESSX_ERROR(m,c) processx__error((m),(c),__FILE__,__LINE__)

--- a/src/test-connections.cpp
+++ b/src/test-connections.cpp
@@ -141,6 +141,7 @@ context("Reading characters") {
 
     processx_pollable_t pollable;
     processx_c_pollable_from_connection(&pollable, ccon);
+    ccon->poll_idx = 0;
 
     char buffer[10];
     processx_c_connection_poll(&pollable, 1, -1);

--- a/src/win/iocp.c
+++ b/src/win/iocp.c
@@ -1,0 +1,21 @@
+
+#include "../processx.h"
+
+HANDLE processx__connection_iocp = NULL;
+
+HANDLE processx__get_default_iocp() {
+
+  if (! processx__connection_iocp) {
+    processx__connection_iocp = CreateIoCompletionPort(
+    /* FileHandle = */                 INVALID_HANDLE_VALUE,
+    /* ExistingCompletionPort = */     NULL,
+    /* CompletionKey = */              0,
+    /* NumberOfConcurrentThreads =  */ 0);
+
+    if (! processx__connection_iocp) {
+      PROCESSX_ERROR("cannot create default IOCP", GetLastError());
+    }
+  }
+
+  return processx__connection_iocp;
+}

--- a/src/win/processx-win.h
+++ b/src/win/processx-win.h
@@ -15,8 +15,6 @@ typedef struct processx_handle_s {
   int cleanup;
 } processx_handle_t;
 
-extern HANDLE processx__iocp;
-
 int processx__utf8_to_utf16_alloc(const char* s, WCHAR** ws_ptr);
 
 int processx__stdio_create(processx_handle_t *handle,

--- a/src/win/stdio.c
+++ b/src/win/stdio.c
@@ -37,6 +37,8 @@
 #define FDEV        0x40
 #define FTEXT       0x80
 
+HANDLE processx__default_iocp = NULL;
+
 static int processx__create_nul_handle(HANDLE *handle_ptr, DWORD access) {
   HANDLE handle;
   SECURITY_ATTRIBUTES sa;
@@ -162,8 +164,6 @@ int processx__create_pipe(void *id, HANDLE* parent_pipe_ptr, HANDLE* child_pipe_
   PROCESSX_ERROR(errmessage, err);
   return 0;			/* never reached */
 }
-
-
 
 processx_connection_t * processx__create_connection(
   HANDLE pipe_handle, const char *membername, SEXP private,

--- a/tests/testthat/test-poll-stress.R
+++ b/tests/testthat/test-poll-stress.R
@@ -1,0 +1,35 @@
+
+context("poll stress test")
+
+test_that("many processes", {
+  skip_on_cran()
+
+  ## Create many processes
+  num <- 100
+  px <- get_tool("px")
+  on.exit(try(lapply(pp, function(x) x$kill()), silent = TRUE), add = TRUE)
+  pp <- lapply(1:num, function(i) {
+    cmd <- c("sleep", "1", "outln", paste("out", i),
+             "errln", paste("err", i))
+    process$new(px, cmd, stdout = "|",  stderr = "|")
+  })
+
+  ## poll them
+  results <- replicate(num, list(character(), character()), simplify = FALSE)
+  while (TRUE) {
+    pr <- poll(pp, -1)
+    lapply(seq_along(pp), function(i) {
+      if (pr[[i]]["output"] == "ready") {
+        results[[i]][[1]] <<- c(results[[i]][[1]], pp[[i]]$read_output_lines())
+      }
+      if (pr[[i]]["error"] == "ready") {
+        results[[i]][[2]] <<- c(results[[i]][[2]], pp[[i]]$read_error_lines())
+      }
+    })
+    inc <- sapply(pp, function(x) x$is_incomplete_output() || x$is_incomplete_error())
+    if (!any(inc)) break
+  }
+
+  exp <- lapply(1:num, function(i) list(paste("out", i), paste("err", i)))
+  expect_identical(exp, results)
+})

--- a/tests/testthat/test-poll2.R
+++ b/tests/testthat/test-poll2.R
@@ -115,13 +115,17 @@ test_that("polling and buffering", {
 
     ## We poll until p1 has output. We read out some of the output,
     ## and leave the rest in the buffer.
+    tick <- Sys.time()
     p1$poll_io(-1)
+    expect_true(Sys.time() - tick < as.difftime(1, units = "secs"))
     expect_equal(p1$read_output_lines(n = 1), "1")
 
     ## Now poll should return immediately, because there is output ready
     ## from p1. The status of p2 should be 'silent' (and not 'timeout')
     tick <- Sys.time()
     s <- poll(list(p1, p2), 3000)
+    dt <- Sys.time() - tick
+    expect_true(dt < as.difftime(2, units = "secs"))
     expect_equal(
       s,
       list(
@@ -129,14 +133,10 @@ test_that("polling and buffering", {
         c(output = "silent", error = "silent")
       )
     )
-    if (s[[2]][1] != "silent") break;
 
     p1$kill()
     p2$kill()
-
-    ## Check that poll has returned immediately
-    dt <- Sys.time() - tick
-    expect_true(dt < as.difftime(2, units = "secs"))
+    if (s[[2]][1] != "silent") break;
   }
 })
 


### PR DESCRIPTION
Instead of `WaitForMultipleObjects`. 

This allows polling more than 64 connections at once. It also simplifies  the workflow a bit.

The polling part is not very clean, because it turns out that the connection -> pollable conversion is not a  very good model. In particular, on Windows, it is hard to find the connection that responses, after a poll. The libuv model (i.e. their "inheritance" between struct types) is a better fit.

