### PR TITLE
poll connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /src/processx.dll
 /src/tools/*.exe
 /src/tools/px
+/src/tools/px.dSYM/
 /src-i386
 /src-x64
 /src/supervisor/supervisor

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 3.1.0.9001
+Version: 3.1.0.9002
 Authors@R: c(
     person("Gábor", "Csárdi", role = c("aut", "cre", "cph"),
            email = "csardi.gabor@gmail.com",

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -82,6 +82,11 @@ process_initialize <- function(self, private, command, args,
   )
   private$starttime <- Sys.time()
 
+  ## Need to close this, otherwise the child's end of the pipe
+  ## will not be closed when the child exits, and then we cannot
+  ## poll it.
+  if (poll_connection) close(pipe[[2]])
+
   if (is.character(stdin) && stdin != "|")
     stdin <- full_path(stdin)
   if (is.character(stdout) && stdout != "|")

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -65,7 +65,7 @@ process_initialize <- function(self, private, command, args,
      !length(connections))
   if (poll_connection) {
     pipe <- conn_create_pipepair()
-    connections <- c(connections, pipe[[2]])
+    connections <- c(connections, list(pipe[[2]]))
     private$poll_pipe <- pipe[[1]]
   }
 

--- a/R/io.R
+++ b/R/io.R
@@ -14,6 +14,11 @@ process_has_error_connection <- function(self, private) {
   !is.null(private$stderr_pipe)
 }
 
+process_has_poll_connection <- function(self, private) {
+  "!DEBUG process_has_error_connection `private$get_short_name()`"
+  !is.null(private$poll_pipe)
+}
+
 process_get_input_connection <- function(self, private) {
   "!DEBUG process_get_input_connection `private$get_short_name()`"
   if (!self$has_input_connection())
@@ -33,6 +38,12 @@ process_get_error_connection <- function(self, private) {
   if (!self$has_error_connection())
     stop("stderr is not a pipe.")
   private$stderr_pipe
+}
+
+process_get_poll_connection <- function(self, private) {
+  "!DEBUG process_get_poll_connection `private$get_short_name()`"
+  if (!self$has_poll_connection()) stop("No poll connection")
+  private$poll_pipe
 }
 
 process_read_output <- function(self, private, n) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,6 @@
 
+`%||%` <- function(l, r) if (is.null(l)) r else l
+
 os_type <- function() {
   .Platform$OS.type
 }
@@ -164,4 +166,8 @@ str_wrap_words <- function(words, width, indent = 0, exdent = 2) {
 set_names <- function(x, n) {
   names(x) <- n
   x
+}
+
+get_private <- function(x) {
+  x$.__enclos_env__$private
 }

--- a/inst/README.markdown
+++ b/inst/README.markdown
@@ -139,13 +139,16 @@ result <- run(px, "--help", echo = TRUE)
 ```
 #> Usage: px [command arg] [command arg] ...
 #> 
-#> Commands:   sleep  <seconds>  -- sleep for a number os seconds
-#>             out    <string>   -- print string to stdout
-#>             err    <string>   -- print string to stderr
-#>             outln  <string>   -- print string to stdout, add newline
-#>             errln  <string>   -- print string to stderr, add newline
-#>             cat    <filename> -- print file to stdout
-#>             return <exitcode> -- return with exitcode
+#> Commands:
+#>   sleep  <seconds>           -- sleep for a number os seconds
+#>   out    <string>            -- print string to stdout
+#>   err    <string>            -- print string to stderr
+#>   outln  <string>            -- print string to stdout, add newline
+#>   errln  <string>            -- print string to stderr, add newline
+#>   cat    <filename>          -- print file to stdout
+#>   return <exitcode>          -- return with exitcode
+#>   write <fd> <string>        -- write to file descriptor
+#>   echo <fd1> <fd2> <nbytes>  -- echo from fd to another fd
 ```
 
 > Note: From version 3.0.1, processx does not let you specify a full
@@ -252,7 +255,7 @@ out2
 #>  [4] "Makefile"           "NAMESPACE"          "NEWS.md"           
 #>  [7] "R"                  "README.Rmd"         "README.markdown"   
 #> [10] "_pkgdown.yml"       "appveyor.yml"       "docs"              
-#> [13] "inst"               "man"                "revdep"            
+#> [13] "inst"               "man"                "processx.Rproj"    
 #> [16] "src"                "tests"
 ```
 
@@ -392,8 +395,8 @@ gc()
 
 ```
 #>          used (Mb) gc trigger (Mb) max used (Mb)
-#> Ncells 422816 22.6     750400 40.1   592000 31.7
-#> Vcells 840479  6.5    1650153 12.6  1061286  8.1
+#> Ncells 423484 22.7     750400 40.1   592000 31.7
+#> Vcells 841455  6.5    1650153 12.6  1076488  8.3
 ```
 
 Here, the direct call to the garbage collector kills the `sleep` process
@@ -495,8 +498,8 @@ p$poll_io(5000)
 ```
 
 ```
-#>   output    error 
-#>  "ready" "nopipe"
+#>   output    error  process 
+#>  "ready" "nopipe" "nopipe"
 ```
 
 ```r
@@ -527,12 +530,12 @@ poll(list(p1 = p1, p2 = p2), 100)
 
 ```
 #> $p1
-#>    output     error 
-#> "timeout"  "nopipe" 
+#>    output     error   process 
+#> "timeout"  "nopipe"  "nopipe" 
 #> 
 #> $p2
-#>    output     error 
-#>  "nopipe" "timeout"
+#>    output     error   process 
+#>  "nopipe" "timeout"  "nopipe"
 ```
 
 ```r
@@ -542,12 +545,12 @@ poll(list(p1 = p1, p2 = p2), 1000)
 
 ```
 #> $p1
-#>   output    error 
-#>  "ready" "nopipe" 
+#>   output    error  process 
+#>  "ready" "nopipe" "nopipe" 
 #> 
 #> $p2
-#>   output    error 
-#> "nopipe" "silent"
+#>   output    error  process 
+#> "nopipe" "silent" "nopipe"
 ```
 
 ```r
@@ -574,12 +577,12 @@ poll(list(p1 = p1, p2 = p2), 5000)
 
 ```
 #> $p1
-#>   output    error 
-#> "closed" "nopipe" 
+#>   output    error  process 
+#> "closed" "nopipe" "nopipe" 
 #> 
 #> $p2
-#>   output    error 
-#> "nopipe"  "ready"
+#>   output    error  process 
+#> "nopipe"  "ready" "nopipe"
 ```
 
 ```r
@@ -612,7 +615,7 @@ Sys.time()
 ```
 
 ```
-#> [1] "2018-05-22 11:30:42 BST"
+#> [1] "2018-05-26 21:00:00 BST"
 ```
 
 ```r
@@ -621,7 +624,7 @@ Sys.time()
 ```
 
 ```
-#> [1] "2018-05-22 11:30:44 BST"
+#> [1] "2018-05-26 21:00:02 BST"
 ```
 
 It is safe to call `wait()` multiple times:
@@ -669,7 +672,7 @@ p <- process$new("nonexistant-command-for-sure")
 ```
 
 ```
-#> Error in process_initialize(self, private, command, args, stdin, stdout, : processx error: 'No such file or directory' at unix/processx.c:403
+#> Error in process_initialize(self, private, command, args, stdin, stdout, : processx error: 'No such file or directory' at unix/processx.c:424
 ```
 
 

--- a/man/poll.Rd
+++ b/man/poll.Rd
@@ -16,12 +16,14 @@ identification of the processes.}
 Supply -1 for an infitite timeout, and 0 for not waiting at all.}
 }
 \value{
-A list of character vectors of length one or two.
-There is one list element for each process, in the same order as in
-the input list. For connections the result is a single string scalar.
-For processes the character vectors' elements are named \code{output} and
-\code{error}. Possible values for each individual result are: \code{nopipe},
-\code{ready}, \code{timeout}, \code{closed}, \code{silent}. See details about these below.
+A list of character vectors of length one or three.
+There is one list element for each connection/process, in the same
+order as in the input list. For connections the result is a single
+string scalar. For processes the character vectors' elements are named
+\code{output}, \code{error} and \code{process}. Possible values for each individual
+result are: \code{nopipe}, \code{ready}, \code{timeout}, \code{closed}, \code{silent}.
+See details about these below. \code{process} refers to the poll connection,
+see the \code{poll_connection} argument of the \code{process} initializer.
 }
 \description{
 Wait until one of the specified connections or processes produce
@@ -42,16 +44,6 @@ started.
 \item \code{silent}: the connection is not ready to read from, but another
 connection was.
 }
-}
-
-\section{Known issues}{
-
-
-\code{poll()} cannot wait on the termination of a process directly. It is
-only signalled through the closed stdout and stderr pipes. This means
-that if both stdout and stderr are ignored or closed for a process,
-then you will not be notified when it exits. If you want to wait for
-just a single process to end, it can be done with the \code{$wait()} method.
 }
 
 \examples{

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -13,7 +13,8 @@ streams. The process id is then used to manage the process.
 \section{Usage}{
 \preformatted{p <- process$new(command = NULL, args,
                  stdin = NULL, stdout = NULL, stderr = NULL,
-                 connections = list(), env = NULL, cleanup = TRUE,
+                 connections = list(), poll_connection = NULL,
+                 env = NULL, cleanup = TRUE,
                  wd = NULL, echo_cmd = FALSE, supervise = FALSE,
                  windows_verbatim_args = FALSE,
                  windows_hide_window = FALSE,
@@ -31,9 +32,14 @@ p$read_output(n = -1)
 p$read_error(n = -1)
 p$read_output_lines(n = -1)
 p$read_error_lines(n = -1)
+p$has_input_connection()
+p$has_output_connection()
+p$has_error_connection()
+p$has_poll_connection()
 p$get_input_connection()
 p$get_output_connection()
 p$get_error_connection()
+p$get_poll_connection()
 p$is_incomplete_output()
 p$is_incomplete_error()
 p$read_all_output()
@@ -77,6 +83,15 @@ provided; a string, supply the specified string as standard input;
 \code{"|"}: create a connection for it.
 \item \code{connections}: A list of connections to pass to the child process.
 This is an experimental feature currently.
+\item \code{poll_connection}: Whether to create an extra connection to the process
+that allows polling, even if the standard input and standard output
+are not pipes. If this is \code{NULL} (the default), then this connection
+will be only created if standard output and standard error are not
+pipes, and \code{connections} is an empty list. If the poll connection is
+created, you can query it via \code{p$get_poll_connection()} and it is
+also included in the response to \code{p$poll_io()} and \code{\link[=poll]{poll()}}. The
+numeric file descriptor of the poll connection comes right after
+\code{stderr} (2), and the connections listed in \code{connections}.
 \item \code{env}: Environment variables of the child process. If \code{NULL}, the
 parent's environment is inherited. On Windows, many programs cannot
 function correctly if some environment variables are not set, so we
@@ -189,12 +204,19 @@ error.
 \code{$read_error_lines()} is similar to \code{$read_output_lines}, but
 it reads from the standard error stream.
 
+\code{$has_input_connection()} return \code{TRUE} if there is a connection
+object for standard input; in other words, if \code{stdout="|"}. It returns
+\code{FALSE} otherwise.
+
 \code{$has_output_connection()} returns \code{TRUE} if there is a connection
 object for standard output; in other words, if \code{stdout="|"}. It returns
 \code{FALSE} otherwise.
 
 \code{$has_error_connection()} returns \code{TRUE} if there is a connection
 object for standard error; in other words, if \code{stderr="|"}. It returns
+\code{FALSE} otherwise.
+
+\code{$has_poll_connection()} return \code{TRUE} if there is a poll connection,
 \code{FALSE} otherwise.
 
 \code{$get_input_connection()} returns a connection object, to the
@@ -205,6 +227,9 @@ standard output stream of the process.
 
 \code{$get_error_conneciton()} returns a connection object, to the
 standard error stream of the process.
+
+\code{$get_poll_connetion()} returns the poll connection, if the process has
+one.
 
 \code{$is_incomplete_output()} return \code{FALSE} if the other end of
 the standard output connection was closed (most probably because the

--- a/man/process_initialize.Rd
+++ b/man/process_initialize.Rd
@@ -5,8 +5,8 @@
 \title{Start a process}
 \usage{
 process_initialize(self, private, command, args, stdin, stdout, stderr,
-  connections, env, cleanup, wd, echo_cmd, supervise, windows_verbatim_args,
-  windows_hide_window, encoding, post_process)
+  connections, poll_connection, env, cleanup, wd, echo_cmd, supervise,
+  windows_verbatim_args, windows_hide_window, encoding, post_process)
 }
 \arguments{
 \item{self}{this}
@@ -24,6 +24,8 @@ process_initialize(self, private, command, args, stdin, stdout, stderr,
 \item{stderr}{Standard error, NULL to ignore, TRUE for temp file.}
 
 \item{connections}{Connections to inherit in the child process.}
+
+\item{poll_connection}{Whether to create a connection for polling.}
 
 \item{env}{Environment vaiables.}
 

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -407,7 +407,7 @@ SEXP processx_exec(SEXP command, SEXP args, SEXP std_in, SEXP std_out,
   }
 
   /* Closed unused ends of pipes */
-  for (i = 0; i < num_connections; i++) {
+  for (i = 0; i < 3; i++) {
     if (pipes[i][1] >= 0) close(pipes[i][1]);
   }
 

--- a/tests/testthat/test-extra-connections.R
+++ b/tests/testthat/test-extra-connections.R
@@ -15,7 +15,7 @@ test_that("writing to extra connection", {
       stdout = "|", stderr = "|", connections = list(pipe[[1]])
     )
   )
-
+  close(pipe[[1]])
   on.exit(p$kill())
 
   conn_write(pipe[[2]], msg)
@@ -39,6 +39,7 @@ test_that("reading from extra connection", {
       connections = list(pipe[[2]])
     )
   )
+  close(pipe[[2]])
 
   ## Nothing to read yet
   expect_equal(conn_read_lines(pipe[[1]]), character())
@@ -65,6 +66,8 @@ test_that("reading and writing to extra connection", {
       connections = list(pipe1[[1]], pipe2[[2]])
     )
   )
+  close(pipe1[[1]])
+  close(pipe2[[2]])
 
   on.exit(p$kill())
 

--- a/tests/testthat/test-poll.R
+++ b/tests/testthat/test-poll.R
@@ -7,19 +7,24 @@ test_that("polling for output available", {
   p <- process$new(px, c("sleep", "1", "outln", "foobar"), stdout = "|")
 
   ## Timeout
-  expect_equal(p$poll_io(0), c(output = "timeout", error = "nopipe"))
+  expect_equal(p$poll_io(0), c(output = "timeout", error = "nopipe",
+                               process = "nopipe"))
 
   p$wait()
-  expect_equal(p$poll_io(-1), c(output = "ready", error = "nopipe"))
+  expect_equal(p$poll_io(-1), c(output = "ready", error = "nopipe",
+                                process = "nopipe"))
 
   p$read_output_lines()
-  expect_equal(p$poll_io(-1), c(output = "ready", error = "nopipe"))
+  expect_equal(p$poll_io(-1), c(output = "ready", error = "nopipe",
+                                process = "nopipe"))
 
   p$kill()
-  expect_equal(p$poll_io(-1), c(output = "ready", error = "nopipe"))
+  expect_equal(p$poll_io(-1), c(output = "ready", error = "nopipe",
+                                process = "nopipe"))
 
   close(p$get_output_connection())
-  expect_equal(p$poll_io(-1), c(output = "closed", error = "nopipe"))
+  expect_equal(p$poll_io(-1), c(output = "closed", error = "nopipe",
+                                process = "nopipe"))
 })
 
 test_that("polling for stderr", {
@@ -28,19 +33,24 @@ test_that("polling for stderr", {
   p <- process$new(px, c("sleep", "1", "errln", "foobar"), stderr = "|")
 
   ## Timeout
-  expect_equal(p$poll_io(0), c(output = "nopipe", error = "timeout"))
+  expect_equal(p$poll_io(0), c(output = "nopipe", error = "timeout",
+                               process = "nopipe"))
 
   p$wait()
-  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "ready"))
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "ready",
+                                process = "nopipe"))
 
   p$read_error_lines()
-  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "ready"))
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "ready",
+                                process = "nopipe"))
 
   p$kill()
-  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "ready"))
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "ready",
+                                process = "nopipe"))
 
   close(p$get_error_connection())
-  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "closed"))
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "closed",
+                                process = "nopipe"))
 })
 
 test_that("polling for both stdout and stderr", {
@@ -50,7 +60,8 @@ test_that("polling for both stdout and stderr", {
                    stdout = "|", stderr = "|")
 
   ## Timeout
-  expect_equal(p$poll_io(0), c(output = "timeout", error = "timeout"))
+  expect_equal(p$poll_io(0), c(output = "timeout", error = "timeout",
+                               process = "nopipe"))
 
   p$wait()
   expect_true("ready" %in% p$poll_io(-1))
@@ -63,7 +74,8 @@ test_that("polling for both stdout and stderr", {
 
   close(p$get_output_connection())
   close(p$get_error_connection())
-  expect_equal(p$poll_io(-1), c(output = "closed", error = "closed"))
+  expect_equal(p$poll_io(-1), c(output = "closed", error = "closed",
+                                process = "nopipe"))
 })
 
 test_that("multiple polls", {

--- a/tests/testthat/test-poll2.R
+++ b/tests/testthat/test-poll2.R
@@ -11,31 +11,31 @@ test_that("single process", {
   ## Timeout
   expect_equal(
     poll(list(p), 0),
-    list(c(output = "timeout", error = "nopipe"))
+    list(c(output = "timeout", error = "nopipe", process = "nopipe"))
   )
 
   p$wait()
   expect_equal(
     poll(list(p), -1),
-    list(c(output = "ready", error = "nopipe"))
+    list(c(output = "ready", error = "nopipe", process = "nopipe"))
   )
 
   p$read_output_lines()
   expect_equal(
     poll(list(p), -1),
-    list(c(output = "ready", error = "nopipe"))
+    list(c(output = "ready", error = "nopipe", process = "nopipe"))
   )
 
   p$kill()
   expect_equal(
     poll(list(p), -1),
-    list(c(output = "ready", error = "nopipe"))
+    list(c(output = "ready", error = "nopipe", process = "nopipe"))
   )
 
   close(p$get_output_connection())
   expect_equal(
     poll(list(p), -1),
-    list(c(output = "closed", error = "nopipe"))
+    list(c(output = "closed", error = "nopipe", process = "nopipe"))
   )
 })
 
@@ -53,14 +53,14 @@ test_that("multiple processes", {
   expect_equal(
     res,
     list(
-      p1 = c(output = "timeout", error = "nopipe"),
-      p2 = c(output = "nopipe", error = "timeout")
+      p1 = c(output = "timeout", error = "nopipe", process = "nopipe"),
+      p2 = c(output = "nopipe", error = "timeout", process = "nopipe")
     )
   )
 
   p1$wait()
   res <- poll(list(p1 = p1, p2 = p2), -1)
-  expect_equal(res$p1, c(output = "ready", error = "nopipe"))
+  expect_equal(res$p1, c(output = "ready", error = "nopipe", process = "nopipe"))
   expect_equal(res$p2[["output"]], "nopipe")
   expect_true(res$p2[["error"]] %in% c("silent", "ready"))
 
@@ -70,8 +70,8 @@ test_that("multiple processes", {
   expect_equal(
     res,
     list(
-      p1 = c(output = "closed", error = "nopipe"),
-      p2 = c(output = "nopipe", error = "ready")
+      p1 = c(output = "closed", error = "nopipe", process = "nopipe"),
+      p2 = c(output = "nopipe", error = "ready", process = "nopipe")
     )
   )
 
@@ -80,8 +80,8 @@ test_that("multiple processes", {
   expect_equal(
     res,
     list(
-      p1 = c(output = "closed", error = "nopipe"),
-      p2 = c(output = "nopipe", error = "closed")
+      p1 = c(output = "closed", error = "nopipe", process = "nopipe"),
+      p2 = c(output = "nopipe", error = "closed", process = "nopipe")
     )
   )
 
@@ -129,8 +129,8 @@ test_that("polling and buffering", {
     expect_equal(
       s,
       list(
-        c(output = "ready", error = "silent"),
-        c(output = "silent", error = "silent")
+        c(output = "ready", error = "silent", process = "nopipe"),
+        c(output = "silent", error = "silent", process = "nopipe")
       )
     )
 
@@ -172,8 +172,8 @@ test_that("polling and buffering #2", {
     expect_equal(
       s,
       list(
-        c(output = "ready", error = "nopipe"),
-        c(output = "ready", error = "nopipe")
+        c(output = "ready", error = "nopipe", process = "nopipe"),
+        c(output = "ready", error = "nopipe", process = "nopipe")
       )
     )
 

--- a/tests/testthat/test-poll3.R
+++ b/tests/testthat/test-poll3.R
@@ -1,0 +1,60 @@
+
+context("poll connection")
+
+test_that("poll connection", {
+  px <- get_tool("px")
+  p <- process$new(px, c("sleep", ".5", "outln", "foobar"))
+  on.exit(p$kill())
+
+  ## Timeout
+  expect_equal(p$poll_io(0), c(output = "nopipe", error = "nopipe",
+                               process = "timeout"))
+
+  p$wait()
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "nopipe",
+                                process = "ready"))
+
+  p$kill()
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "nopipe",
+                                process = "ready"))
+
+  close(p$get_poll_connection())
+  expect_equal(p$poll_io(-1), c(output = "nopipe", error = "nopipe",
+                                process = "closed"))
+})
+
+test_that("poll connection + stdout", {
+
+  px <- get_tool("px")
+  p1 <- process$new(px, c("outln", "foobar"), stdout = "|")
+  on.exit(p1$kill(), add = TRUE)
+
+  expect_false(p1$has_poll_connection())
+
+  p2 <- process$new(px, c("sleep", "0.5", "outln", "foobar"), stdout = "|",
+                   poll_connection = TRUE)
+  on.exit(p2$kill(), add = TRUE)
+
+  expect_equal(p2$poll_io(0), c(output = "timeout", error = "nopipe",
+                                process = "timeout"))
+
+  pr <- p2$poll_io(-1)
+  expect_true("ready" %in% pr)
+})
+
+test_that("poll connection + stderr", {
+
+  px <- get_tool("px")
+  p1 <- process$new(px, c("errln", "foobar"), stderr = "|")
+  on.exit(p1$kill(), add = TRUE)
+
+  expect_false(p1$has_poll_connection())
+
+  p2 <- process$new(px, c("sleep", "0.5", "errln", "foobar"), stderr = "|",
+                   poll_connection = TRUE)
+  on.exit(p2$kill(), add = TRUE)
+
+  expect_equal(p2$poll_io(0), c(output = "nopipe", error = "timeout",
+                                process = "timeout"))
+
+})


### PR DESCRIPTION
A special connection that can be used to poll for the termination
of the process. It is created by default if neither stdout, nor
stderr are written to a pipe, and no extra connections are passed
to the child process. It can also be forced with the `poll_connection`
argument.

So $poll_io() and poll() now return three-element character vectors
for processes: 'input', 'output' and 'process'.

Closes #50, closes #101.