### PR TITLE
Send interrupt to background process

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 3.1.0.9003
+Version: 3.1.0.9004
 Authors@R: c(
     person("Gábor", "Csárdi", role = c("aut", "cre", "cph"),
            email = "csardi.gabor@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 3.1.0.9002
+Version: 3.1.0.9003
 Authors@R: c(
     person("Gábor", "Csárdi", role = c("aut", "cre", "cph"),
            email = "csardi.gabor@gmail.com",

--- a/R/process.R
+++ b/R/process.R
@@ -23,6 +23,7 @@ NULL
 #'
 #' p$is_alive()
 #' p$signal(signal)
+#' p$interrupt()
 #' p$kill(grace = 0.1)
 #' p$wait(timeout = -1)
 #' p$get_pid()
@@ -143,6 +144,11 @@ NULL
 #' signal return `TRUE` if the process is alive, and `FALSE`
 #' otherwise. On Unix all signals are supported that the OS supports, and
 #' the 0 signal as well.
+#'
+#' `$interrupt()` sends an interrupt to the process. On Unix this is a
+#' `SIGINT` signal, and it is usually equivalent to pressing CTRL+C at the
+#' terminal prompt. On Windows, it is a CTRL+BREAK keypress. Applications
+#' may catch these events. By default they will quit.
 #'
 #' `$kill()` kills the process. It also kills all of its child
 #' processes, except if they have created a new process group (on Unix),
@@ -350,6 +356,9 @@ process <- R6Class(
     signal = function(signal)
       process_signal(self, private, signal),
 
+    interrupt = function()
+      process_interrupt(self, private),
+
     get_pid = function()
       process_get_pid(self, private),
 
@@ -534,6 +543,15 @@ process_signal <- function(self, private, signal) {
     FALSE
   } else {
     .Call(c_processx_signal, private$status, as.integer(signal))
+  }
+}
+
+process_interrupt <- function(self, private) {
+  "!DEBUG process_interrupt `private$get_short_name()`"
+  if (private$exited) {
+    FALSE
+  } else {
+    .Call(c_processx_interrupt, private$status)
   }
 }
 

--- a/R/process.R
+++ b/R/process.R
@@ -551,7 +551,13 @@ process_interrupt <- function(self, private) {
   if (private$exited) {
     FALSE
   } else {
-    .Call(c_processx_interrupt, private$status)
+    if (os_type() == "windows") {
+      pid <- private$pid
+      st <- run(get_tool("interrupt"), c(pid, "c"), error_on_status = FALSE)
+      if (st$status == 0) TRUE else FALSE
+    } else {
+      .Call(c_processx_interrupt, private$status)
+    }
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,3 +171,15 @@ set_names <- function(x, n) {
 get_private <- function(x) {
   x$.__enclos_env__$private
 }
+
+get_tool <- function(prog) {
+  if (os_type() == "windows") prog <- paste0(prog, ".exe")
+  exe <- system.file(package = "processx", "bin", .Platform$r_arch, prog)
+  if (exe == "") {
+    pkgpath <- system.file(package = "processx")
+    if (basename(pkgpath) == "inst") pkgpath <- dirname(pkgpath)
+    exe <- file.path(pkgpath, "src", "tools", prog)
+    if (!file.exists(exe)) return("")
+  }
+  exe
+}

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -22,6 +22,7 @@ streams. The process id is then used to manage the process.
 
 p$is_alive()
 p$signal(signal)
+p$interrupt()
 p$kill(grace = 0.1)
 p$wait(timeout = -1)
 p$get_pid()
@@ -148,6 +149,11 @@ and the special 0 signal, The first three all kill the process. The 0
 signal return \code{TRUE} if the process is alive, and \code{FALSE}
 otherwise. On Unix all signals are supported that the OS supports, and
 the 0 signal as well.
+
+\code{$interrupt()} sends an interrupt to the process. On Unix this is a
+\code{SIGINT} signal, and it is usually equivalent to pressing CTRL+C at the
+terminal prompt. On Windows, it is a CTRL+BREAK keypress. Applications
+may catch these events. By default they will quit.
 
 \code{$kill()} kills the process. It also kills all of its child
 processes, except if they have created a new process group (on Unix),

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,9 +5,13 @@ OBJECTS = test-connections.o init.o poll.o processx-connection.o     \
 
 .PHONY: all clean
 
-all: tools/px.exe supervisor/supervisor.exe $(SHLIB)
+all: tools/px.exe tools/interrupt.exe \
+	supervisor/supervisor.exe $(SHLIB)
 
 tools/px.exe: tools/px.c
+	$(CC) $(CFLAGS) -Wall $< -o $@
+
+tools/interrupt.exe: tools/interrupt.c
 	$(CC) $(CFLAGS) -Wall $< -o $@
 
 supervisor/supervisor.exe: supervisor/supervisor.c supervisor/utils.c \
@@ -17,4 +21,4 @@ supervisor/supervisor.exe: supervisor/supervisor.c supervisor/utils.c \
 clean:
 	rm -rf $(SHLIB) $(OBJECTS) \
 	    supervisor/supervisor supervisor/supervisor.dSYM \
-	    supervisor/supervisor.exe wintools/sleep.exe
+	    supervisor/supervisor.exe tools/px.exe tools/interrupt.exe

--- a/src/init.c
+++ b/src/init.c
@@ -15,6 +15,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_is_alive",           (DL_FUNC) &processx_is_alive,           1 },
   { "processx_get_exit_status",    (DL_FUNC) &processx_get_exit_status,    1 },
   { "processx_signal",             (DL_FUNC) &processx_signal,             2 },
+  { "processx_interrupt",          (DL_FUNC) &processx_interrupt,          1 },
   { "processx_kill",               (DL_FUNC) &processx_kill,               2 },
   { "processx_get_pid",            (DL_FUNC) &processx_get_pid,            1 },
   { "processx_poll",               (DL_FUNC) &processx_poll,               3 },

--- a/src/processx.h
+++ b/src/processx.h
@@ -46,6 +46,7 @@ SEXP processx_wait(SEXP status, SEXP timeout);
 SEXP processx_is_alive(SEXP status);
 SEXP processx_get_exit_status(SEXP status);
 SEXP processx_signal(SEXP status, SEXP signal);
+SEXP processx_interrupt(SEXP status);
 SEXP processx_kill(SEXP status, SEXP grace);
 SEXP processx_get_pid(SEXP status);
 

--- a/src/tools/interrupt.c
+++ b/src/tools/interrupt.c
@@ -1,0 +1,40 @@
+
+#include <stdio.h>
+#include <string.h>
+#include <windows.h>
+
+int main(int argc, const char **argv) {
+
+  int ctrlbreak = 1;
+  int pid;
+  int ret;
+  BOOL bret;
+
+  if (argc == 1) return 1;
+  ret = sscanf(argv[1], "%d", &pid);
+  if (ret != 1) return 1;
+  printf("Pid: %d\n", pid);
+
+  if (argc == 3 && !strcmp(argv[2], "c")) ctrlbreak = 0;
+  printf("Event: %s\n", ctrlbreak ? "ctrl+break" : "ctrl+c");
+
+  printf("Free console\n");
+  bret = FreeConsole();
+  if (!bret) return GetLastError();
+
+  printf("Attach console\n");
+  bret = AttachConsole(pid);
+  if (!bret) return GetLastError();
+
+  printf("Set console ctrl handler\n");
+  SetConsoleCtrlHandler(NULL, TRUE);
+
+  printf("Send event\n");
+  bret = GenerateConsoleCtrlEvent(
+    ctrlbreak ? CTRL_BREAK_EVENT : CTRL_C_EVENT,
+    0);
+  if (!bret) return GetLastError();
+
+  printf("Done\n");
+  return 0;
+}

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -739,6 +739,10 @@ SEXP processx_signal(SEXP status, SEXP signal) {
   return ScalarLogical(result);
 }
 
+SEXP processx_interrupt(SEXP status) {
+  return processx_signal(status, ScalarInteger(2));
+}
+
 /* This is a special case of `processx_signal`, and we implement it almost
  * the same way. We make an effort to return a TRUE/FALSE value to indicate
  * if the process died as a response to our KILL signal. This is not 100%

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -1171,7 +1171,7 @@ SEXP processx_signal(SEXP status, SEXP signal) {
 }
 
 SEXP processx_interrupt(SEXP status) {
-  /* TODO */
+  error("Internal processx error, `processx_interrupt()` should not be called");
   return R_NilValue;
 }
 

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -1170,6 +1170,11 @@ SEXP processx_signal(SEXP status, SEXP signal) {
   }
 }
 
+SEXP processx_interrupt(SEXP status) {
+  /* TODO */
+  return R_NilValue;
+}
+
 SEXP processx_kill(SEXP status, SEXP grace) {
   return processx_signal(status, ScalarInteger(9));
 }

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -1005,7 +1005,7 @@ SEXP processx_exec(SEXP command, SEXP args,
 
   /* If the process isn't spawned as detached, assign to the global job */
   /* object so windows will kill it when the parent process dies. */
-  if (!ccleanup) {
+  if (ccleanup) {
     if (! processx__global_job_handle) processx__init_global_job_handle();
 
     if (!AssignProcessToJobObject(processx__global_job_handle, info.hProcess)) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -16,18 +16,6 @@ try_silently <- function(expr) {
   )
 }
 
-get_tool <- function(prog) {
-  if (os_type() == "windows") prog <- paste0(prog, ".exe")
-  exe <- system.file(package = "processx", "bin", .Platform$r_arch, prog)
-  if (exe == "") {
-    pkgpath <- system.file(package = "processx")
-    if (basename(pkgpath) == "inst") pkgpath <- dirname(pkgpath)
-    exe <- file.path(pkgpath, "src", "tools", prog)
-    if (!file.exists(exe)) return("")
-  }
-  exe
-}
-
 get_pid_by_name <- function(name) {
   if (os_type() == "windows") {
     get_pid_by_name_windows(name)


### PR DESCRIPTION
This is a `SIGINT` on Unix, and a CTRL+C  on Windows.

It is on top of #125. Closes #126.