### PR TITLE
Fixes #112

### DIFF
--- a/src/processx-connection.h
+++ b/src/processx-connection.h
@@ -5,6 +5,8 @@
 #ifdef __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
+#elif defined __GNUC__
+#define _XOPEN_SOURCE 500
 #endif
 
 #include <Rinternals.h>

--- a/src/processx-connection.h
+++ b/src/processx-connection.h
@@ -2,7 +2,7 @@
 #ifndef PROCESSX_CONNECTION_H
 #define PROCESSX_CONNECTION_H
 
-#ifdef __INTEL_COMPILER || __GNUC__
+#if defined __INTEL_COMPILER || defined __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
 #endif

--- a/src/processx-connection.h
+++ b/src/processx-connection.h
@@ -2,11 +2,9 @@
 #ifndef PROCESSX_CONNECTION_H
 #define PROCESSX_CONNECTION_H
 
-#ifdef __INTEL_COMPILER
+#ifdef __INTEL_COMPILER || __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
-#elif defined __GNUC__
-#define _XOPEN_SOURCE 500
 #endif
 
 #include <Rinternals.h>

--- a/src/processx-types.h
+++ b/src/processx-types.h
@@ -7,6 +7,7 @@
 typedef DWORD pid_t;
 #else
 #include <signal.h>
+#include <sys/types.h>
 #endif
 
 typedef struct {

--- a/src/processx.h
+++ b/src/processx.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-#ifdef __INTEL_COMPILER || __GNUC__
+#if defined __INTEL_COMPILER || defined __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
 #endif

--- a/src/processx.h
+++ b/src/processx.h
@@ -6,11 +6,9 @@
 extern "C" {
 #endif
 
-#ifdef __INTEL_COMPILER
+#ifdef __INTEL_COMPILER || __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
-#elif defined __GNUC__
-#define _XOPEN_SOURCE 500
 #endif
 
 #ifdef _WIN32

--- a/src/processx.h
+++ b/src/processx.h
@@ -9,6 +9,8 @@ extern "C" {
 #ifdef __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
+#elif defined __GNUC__
+#define _XOPEN_SOURCE 500
 #endif
 
 #ifdef _WIN32

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -26,11 +26,9 @@
 // * Kill the parent processes.
 // * Kill a child process.
 
-#ifdef __INTEL_COMPILER
+#ifdef __INTEL_COMPILER || __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
-#elif defined __GNUC__
-#define _XOPEN_SOURCE 500
 #endif
 
 #include <stdio.h>

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -29,6 +29,8 @@
 #ifdef __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
+#elif defined __GNUC__
+#define _XOPEN_SOURCE 500
 #endif
 
 #include <stdio.h>

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -26,7 +26,7 @@
 // * Kill the parent processes.
 // * Kill a child process.
 
-#ifdef __INTEL_COMPILER || __GNUC__
+#if defined __INTEL_COMPILER || defined __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
 #endif

--- a/src/supervisor/utils.c
+++ b/src/supervisor/utils.c
@@ -1,5 +1,5 @@
 
-#ifdef __INTEL_COMPILER || __GNUC__
+#if defined __INTEL_COMPILER || defined __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
 #endif

--- a/src/supervisor/utils.c
+++ b/src/supervisor/utils.c
@@ -1,9 +1,7 @@
 
-#ifdef __INTEL_COMPILER
+#ifdef __INTEL_COMPILER || __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
-#elif defined __GNUC__
-#define _XOPEN_SOURCE 500
 #endif
 
 #include <stdio.h>

--- a/src/supervisor/utils.c
+++ b/src/supervisor/utils.c
@@ -2,6 +2,8 @@
 #ifdef __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
+#elif defined __GNUC__
+#define _XOPEN_SOURCE 500
 #endif
 
 #include <stdio.h>

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -1,5 +1,5 @@
 
-#ifdef __INTEL_COMPILER || __GNUC__
+#if defined __INTEL_COMPILER || defined __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
 #endif

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -1,5 +1,10 @@
 
+#ifdef __INTEL_COMPILER
+#define _BSD_SOURCE 1
+#define _POSIX_C_SOURCE  200809L
+#elif defined __GNUC__
 #define _XOPEN_SOURCE 500
+#endif
 
 #include <unistd.h>
 #include <stdio.h>

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -1,11 +1,12 @@
 
+#define _XOPEN_SOURCE 500
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <sys/types.h>
 
 void usage() {
   fprintf(stderr, "Usage: px [command arg] [command arg] ...\n\n");

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -1,9 +1,7 @@
 
-#ifdef __INTEL_COMPILER
+#ifdef __INTEL_COMPILER || __GNUC__
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L
-#elif defined __GNUC__
-#define _XOPEN_SOURCE 500
 #endif
 
 #include <unistd.h>

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/types.h>
 
 void usage() {
   fprintf(stderr, "Usage: px [command arg] [command arg] ...\n\n");


### PR DESCRIPTION
I started going through the code, because processx didn't compile on our cluster environment. This threw the `useconds_t is undefined` error, that @dominik-handler also saw; likely only due to missing includes.

Sure enough, `px.c` is missing defines for `__INTEL_COMPILER`, but as we're using `gcc`, not `icc`, I augmented the definitions, to include `#elif define __GNUC__` in all relevant files along the way.

Finally, c99 expects `pid_t` to be defined in `<sys/types.h>` so including this in in `process-types.h` did the trick. It all compiles fine now.

For the sake of consistency I stuck with `_XOPEN_SOURCE 500` as a conservative manner, which was sufficient throughout.