### PR TITLE
Fix a Unix crash, because of the child list SEXP references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ pandoc: false
 
 matrix:
   include:
+    - r: 3.1
+    - r: 3.2
+    - r: 3.3
+    - r: 3.4
+    - r: release
+      env: R_CODECOV=true
     - r: devel
     - os: osx
       osx_image: xcode9.3 #High Sierra

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ pandoc: false
 
 matrix:
   include:
-    - r: 3.1
-    - r: 3.2
-    - r: 3.3
-    - r: 3.4
-    - r: release
-      env: R_CODECOV=true
     - r: devel
     - os: osx
       osx_image: xcode9.3 #High Sierra

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,30 @@ matrix:
     - os: osx
       osx_image: xcode7.3 #El-Capitan
 
+before_script:
+  - ulimit -c unlimited -S       # enable core dumps
+  - rm -rf /cores/core.*
+
 after_success:
   - test $R_CODECOV && Rscript -e 'covr::codecov()'
+
+after_failure:
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+      for c in $(ls /cores/core.*); do
+        lldb -c $c -o "bt all" -b;
+      done
+    fi
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+      for x in $(ls core*); do
+        gdb -c $c -ex bt -ex "set pagination 0" -batch;
+      done
+    fi
 
 env:
   global:
     - NOT_CRAN=true
+
+addons:
+  apt:
+    packages:
+    - gdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 before_script:
   - ulimit -c unlimited -S       # enable core dumps
   - rm -rf /cores/core.*
+  - rm -rf ~/Library/Logs/DiagnosticReports/*
 
 after_success:
   - test $R_CODECOV && Rscript -e 'covr::codecov()'
@@ -26,12 +27,15 @@ after_failure:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       for c in $(ls /cores/core.*); do
         lldb -c $c -o "bt all" -b;
-      done
+      done;
+      for c in $(ls ~/Library/Logs/DiagnosticReports); do
+        cat ~/Library/Logs/DiagnosticReports/$c;
+      done;
     fi
   - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-      for x in $(ls core*); do
+      for c in $(ls core*); do
         gdb -c $c -ex bt -ex "set pagination 0" -batch;
-      done
+      done;
     fi
 
 env:

--- a/R/process.R
+++ b/R/process.R
@@ -513,7 +513,9 @@ process_wait <- function(self, private, timeout) {
   "!DEBUG process_wait `private$get_short_name()`"
   if (private$exited) {
     ## Nothing
+    print("already gone")
   } else {
+    print("call to wait")
     .Call(c_processx_wait, private$status, as.integer(timeout))
   }
   invisible(self)

--- a/R/process.R
+++ b/R/process.R
@@ -513,9 +513,7 @@ process_wait <- function(self, private, timeout) {
   "!DEBUG process_wait `private$get_short_name()`"
   if (private$exited) {
     ## Nothing
-    print("already gone")
   } else {
-    print("call to wait")
     .Call(c_processx_wait, private$status, as.integer(timeout))
   }
   invisible(self)

--- a/src/init.c
+++ b/src/init.c
@@ -25,8 +25,6 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_close_named_pipe",   (DL_FUNC) &processx_close_named_pipe,   1 },
   { "processx_create_named_pipe",  (DL_FUNC) &processx_create_named_pipe,  2 },
   { "processx_write_named_pipe",   (DL_FUNC) &processx_write_named_pipe,   2 },
-  { "processx__disconnect_process_handle",
-    (DL_FUNC) &processx__disconnect_process_handle, 1 },
 
   { "processx_connection_create",     (DL_FUNC) &processx_connection_create,     2 },
   { "processx_connection_read_chars", (DL_FUNC) &processx_connection_read_chars, 2 },

--- a/src/processx-connection.c
+++ b/src/processx-connection.c
@@ -1019,12 +1019,7 @@ static void processx__connection_find_lines(processx_connection_t *ccon,
 
 static void processx__connection_xfinalizer(SEXP con) {
   processx_connection_t *ccon = R_ExternalPtrAddr(con);
-
-  REprintf("Finalizing a connection\n");
-  
   processx_c_connection_destroy(ccon);
-
-  REprintf("done Finalizing a connection\n");
 }
 
 static ssize_t processx__find_newline(processx_connection_t *ccon,

--- a/src/processx-connection.c
+++ b/src/processx-connection.c
@@ -1020,7 +1020,11 @@ static void processx__connection_find_lines(processx_connection_t *ccon,
 static void processx__connection_xfinalizer(SEXP con) {
   processx_connection_t *ccon = R_ExternalPtrAddr(con);
 
+  REprintf("Finalizing a connection\n");
+  
   processx_c_connection_destroy(ccon);
+
+  REprintf("done Finalizing a connection\n");
 }
 
 static ssize_t processx__find_newline(processx_connection_t *ccon,

--- a/src/processx.h
+++ b/src/processx.h
@@ -53,7 +53,6 @@ SEXP processx_get_pid(SEXP status);
 SEXP processx_poll(SEXP statuses, SEXP conn, SEXP ms);
 
 SEXP processx__process_exists(SEXP pid);
-SEXP processx__disconnect_process_handle(SEXP status);
 
 SEXP processx_is_named_pipe_open(SEXP pipe_ext);
 SEXP processx_close_named_pipe(SEXP pipe_ext);

--- a/src/unix/childlist.c
+++ b/src/unix/childlist.c
@@ -28,6 +28,7 @@ int processx__child_add(pid_t pid, SEXP status) {
   processx__child_list_t *child = calloc(1, sizeof(processx__child_list_t));
   if (!child) return 1;
   child->pid = pid;
+  R_PreserveObject(status);
   child->status = status;
   child->next = child_list->next;
   child_list->next = child;
@@ -42,7 +43,7 @@ void processx__child_remove(pid_t pid) {
   while (ptr) {
     if (ptr->pid == pid) {
       prev->next = ptr->next;
-      memset(ptr, 0, sizeof(*ptr));
+      R_ReleaseObject(ptr->status);
       /* Defer freeing the memory, because malloc/free are typically not
 	 reentrant, and if we free in the SIGCHLD handler, that can cause
 	 crashes. The test case in test-run.R (see comments there)

--- a/src/unix/childlist.c
+++ b/src/unix/childlist.c
@@ -18,18 +18,27 @@ void processx__freelist_free() {
   processx__child_list_t *ptr = child_free_list->next;
   while (ptr) {
     processx__child_list_t *next = ptr->next;
+    R_ReleaseObject(ptr->weak_status);
     free(ptr);
     ptr = next;
   }
   child_free_list->next = 0;
 }
 
+void processx__child_finalizer(SEXP x) {
+  /* Nothing to do here, there is a finalizer on the xPTR */
+}
+
 int processx__child_add(pid_t pid, SEXP status) {
   processx__child_list_t *child = calloc(1, sizeof(processx__child_list_t));
+  SEXP weak_ref;
   if (!child) return 1;
+
+  weak_ref = R_MakeWeakRefC(status, R_NilValue, processx__child_finalizer, 1);
+
   child->pid = pid;
-  R_PreserveObject(status);
-  child->status = status;
+  R_PreserveObject(weak_ref);
+  child->weak_status = weak_ref;
   child->next = child_list->next;
   child_list->next = child;
   return 0;
@@ -43,7 +52,6 @@ void processx__child_remove(pid_t pid) {
   while (ptr) {
     if (ptr->pid == pid) {
       prev->next = ptr->next;
-      R_ReleaseObject(ptr->status);
       /* Defer freeing the memory, because malloc/free are typically not
 	 reentrant, and if we free in the SIGCHLD handler, that can cause
 	 crashes. The test case in test-run.R (see comments there)
@@ -77,9 +85,9 @@ SEXP processx__killem_all() {
 
   while (ptr) {
     processx__child_list_t *next = ptr->next;
-    SEXP status = ptr->status;
+    SEXP status = R_WeakRefKey(ptr->weak_status);
     processx_handle_t *handle =
-      (processx_handle_t*) R_ExternalPtrAddr(status);
+      isNull(status) ? 0 : (processx_handle_t*) R_ExternalPtrAddr(status);
     int wp, wstat;
 
     if (handle && handle->cleanup) {
@@ -92,7 +100,7 @@ SEXP processx__killem_all() {
 
     /* waitpid errors are ignored here... */
 
-    R_ClearExternalPtr(status);
+    if (!isNull(status)) R_ClearExternalPtr(status);
     /* The handle will be freed in the finalizer, otherwise there is
        a race condition here. */
 

--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -38,7 +38,7 @@ SEXP processx__killem_all();
 
 typedef struct processx__child_list_s {
   pid_t pid;
-  SEXP status;
+  SEXP weak_status;
   struct processx__child_list_s *next;
 } processx__child_list_t;
 

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -181,6 +181,8 @@ void processx__finalizer(SEXP status) {
 
   pid = handle->pid;
 
+  REprintf("Finalizing %d\n", pid);
+  
   if (handle->cleanup) {
     /* Do a non-blocking waitpid() to see if it is running */
     do {
@@ -200,6 +202,8 @@ void processx__finalizer(SEXP status) {
     }
   }
 
+  REprintf("copying over status\n");
+  
   /* Copy over pid and exit status */
   private = PROTECT(R_ExternalPtrTag(status));
   if (!isNull(private)) {
@@ -220,6 +224,7 @@ void processx__finalizer(SEXP status) {
      any more. */
 
   /* Deallocate memory */
+  REprintf("destroying status\n");
   R_ClearExternalPtr(status);
   processx__handle_destroy(handle);
 
@@ -488,6 +493,7 @@ SEXP processx_wait(SEXP status, SEXP timeout) {
   int ret = 0;
   pid_t pid;
 
+  REprintf("wait\n");
   processx__block_sigchld();
 
   if (!handle) {
@@ -499,12 +505,17 @@ SEXP processx_wait(SEXP status, SEXP timeout) {
 
   /* If we already have the status, then return now. */
   if (handle->collected) {
+    REprintf("handle collected\n");
     processx__unblock_sigchld();
     return ScalarLogical(1);
   }
 
+  REprintf("handle active\n");
+
   /* Make sure this is active, in case another package replaced it... */
+  REprintf("setup sigchld\n");
   processx__setup_sigchld();
+  REprintf("block sigchld after setting up\n");
   processx__block_sigchld();
 
   /* Setup the self-pipe that we can poll */
@@ -524,12 +535,14 @@ SEXP processx_wait(SEXP status, SEXP timeout) {
 
   while (ctimeout < 0 || timeleft > PROCESSX_INTERRUPT_INTERVAL) {
     do {
+      REprintf("polling\n");
       ret = poll(&fd, 1, PROCESSX_INTERRUPT_INTERVAL);
     } while (ret == -1 && errno == EINTR);
 
     /* If not a timeout, then we are done */
     if (ret != 0) break;
 
+    REprintf("Checking for interrupt\n");
     R_CheckUserInterrupt();
 
     /* We also check if the process is alive, because the SIGCHLD is
@@ -557,9 +570,11 @@ SEXP processx_wait(SEXP status, SEXP timeout) {
   }
 
  cleanup:
+  REprintf("Cleaning up\n");
   if (handle->waitpipe[0] >= 0) close(handle->waitpipe[0]);
   if (handle->waitpipe[1] >= 0) close(handle->waitpipe[1]);
   handle->waitpipe[0] = -1;
+  handle->waitpipe[1] = -1;
 
   return ScalarLogical(ret != 0);
 }

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -52,12 +52,12 @@ extern processx__child_list_t *child_free_list;
 
 void R_init_processx_unix() {
   child_list_head.pid = 0;
-  child_list_head.status = 0;
+  child_list_head.weak_status = R_NilValue;
   child_list_head.next = 0;
   child_list = &child_list_head;
 
   child_free_list_head.pid = 0;
-  child_free_list_head.status = 0;
+  child_free_list_head.weak_status = R_NilValue;
   child_free_list_head.next = 0;
   child_free_list = &child_free_list_head;
 }

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -160,16 +160,10 @@ static void processx__child_init(processx_handle_t* handle, int (*pipes)[2],
 
 /* LCOV_EXCL_STOP */
 
-SEXP processx__disconnect_process_handle(SEXP status) {
-  R_SetExternalPtrTag(status, R_NilValue);
-  return R_NilValue;
-}
-
 void processx__finalizer(SEXP status) {
   processx_handle_t *handle = (processx_handle_t*) R_ExternalPtrAddr(status);
   pid_t pid;
   int wp, wstat;
-  SEXP private;
 
   processx__block_sigchld();
 
@@ -199,21 +193,6 @@ void processx__finalizer(SEXP status) {
       processx__collect_exit_status(status, wp, wstat);
     }
   }
-
-  /* Copy over pid and exit status */
-  private = PROTECT(R_ExternalPtrTag(status));
-  if (!isNull(private)) {
-    SEXP sone = PROTECT(ScalarLogical(1));
-    SEXP spid = PROTECT(ScalarInteger(pid));
-    SEXP sexitcode = PROTECT(ScalarInteger(handle->exitcode));
-
-    defineVar(install("exited"), sone, private);
-    defineVar(install("pid"), spid, private);
-    defineVar(install("exitcode"), sexitcode, private);
-    UNPROTECT(3);
-  }
-
-  UNPROTECT(1);
 
   /* Note: if no cleanup is requested, then we still have a sigchld
      handler, to read out the exit code via waitpid, but no handle

--- a/src/unix/sigchld.c
+++ b/src/unix/sigchld.c
@@ -42,16 +42,17 @@ void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx) {
 	 might even trigger the SIGCHLD handler...
       */
 
-      processx_handle_t *handle = R_ExternalPtrAddr(ptr->status);
+      SEXP status = R_WeakRefKey(ptr->weak_status);
+      processx_handle_t *handle =
+	isNull(status) ? 0 : R_ExternalPtrAddr(status);
 
       /* If waitpid errored with ECHILD, then the exit status is set to NA */
-      if (handle) processx__collect_exit_status(ptr->status, wp, wstat);
+      if (handle) processx__collect_exit_status(status, wp, wstat);
 
       /* Defer freeing the memory, because malloc/free are typically not
 	 reentrant, and if we free in the SIGCHLD handler, that can cause
 	 crashes. The test case in test-run.R (see comments there)
 	 typically brings this out. */
-      R_ReleaseObject(ptr->status);
       processx__freelist_add(ptr);
 
       /* If there is an active wait() with a timeout, then stop it */

--- a/src/unix/sigchld.c
+++ b/src/unix/sigchld.c
@@ -30,7 +30,6 @@ void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx) {
       ptr = next;
 
     } else {
-      REprintf("sigchld remove  %d\n", ptr->pid);
       /* Remove the child from the list */
 
       /* We deliberately do not call the finalizer here, because that

--- a/src/unix/sigchld.c
+++ b/src/unix/sigchld.c
@@ -51,7 +51,7 @@ void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx) {
 	 reentrant, and if we free in the SIGCHLD handler, that can cause
 	 crashes. The test case in test-run.R (see comments there)
 	 typically brings this out. */
-      /* memset(ptr, 0, sizeof(*ptr)); */
+      R_ReleaseObject(ptr->status);
       processx__freelist_add(ptr);
 
       /* If there is an active wait() with a timeout, then stop it */

--- a/src/unix/sigchld.c
+++ b/src/unix/sigchld.c
@@ -51,7 +51,7 @@ void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx) {
 	 reentrant, and if we free in the SIGCHLD handler, that can cause
 	 crashes. The test case in test-run.R (see comments there)
 	 typically brings this out. */
-      memset(ptr, 0, sizeof(*ptr));
+      /* memset(ptr, 0, sizeof(*ptr)); */
       processx__freelist_add(ptr);
 
       /* If there is an active wait() with a timeout, then stop it */

--- a/src/unix/sigchld.c
+++ b/src/unix/sigchld.c
@@ -30,6 +30,7 @@ void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx) {
       ptr = next;
 
     } else {
+      REprintf("sigchld remove  %d\n", ptr->pid);
       /* Remove the child from the list */
 
       /* We deliberately do not call the finalizer here, because that

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -785,14 +785,8 @@ DWORD processx__terminate(processx_handle_t *handle, SEXP status) {
   return err;
 }
 
-SEXP processx__disconnect_process_handle(SEXP status) {
-  R_SetExternalPtrTag(status, R_NilValue);
-  return R_NilValue;
-}
-
 void processx__finalizer(SEXP status) {
   processx_handle_t *handle = (processx_handle_t*) R_ExternalPtrAddr(status);
-  SEXP private;
 
   if (!handle) return;
 
@@ -800,20 +794,6 @@ void processx__finalizer(SEXP status) {
     /* Just in case it is running */
     processx__terminate(handle, status);
   }
-
-  /* Copy over pid and exit status */
-  private = PROTECT(R_ExternalPtrTag(status));
-  if (!isNull(private)) {
-    SEXP sone = PROTECT(ScalarLogical(1));
-    SEXP spid = PROTECT(ScalarInteger(handle->dwProcessId));
-    SEXP sexitcode = PROTECT(ScalarInteger(handle->exitcode));
-
-    defineVar(install("exited"), sone, private);
-    defineVar(install("pid"), spid, private);
-    defineVar(install("exitcode"), sexitcode, private);
-    UNPROTECT(3);
-  }
-  UNPROTECT(1);
 
   if (handle->hProcess) CloseHandle(handle->hProcess);
   R_ClearExternalPtr(status);

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -3,6 +3,8 @@ context("Cleanup")
 
 test_that("process is cleaned up", {
 
+  skip("gc cleanup temporarily does not work")
+  
   px <- get_tool("px")
   p <- process$new(px, c("sleep", "1"), cleanup = TRUE)
   pid <- p$get_pid()

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -3,8 +3,6 @@ context("Cleanup")
 
 test_that("process is cleaned up", {
 
-  skip("gc cleanup temporarily does not work")
-  
   px <- get_tool("px")
   p <- process$new(px, c("sleep", "1"), cleanup = TRUE)
   pid <- p$get_pid()

--- a/tests/testthat/test-wait.R
+++ b/tests/testthat/test-wait.R
@@ -30,7 +30,7 @@ test_that("wait with timeout", {
 test_that("wait after process already exited", {
 
   px <- get_tool("px")
-  
+
   pxs <- replicate(20, process$new(px, c("outln",  "foo", "outln", "bar")))
   rm(pxs)
 

--- a/tests/testthat/test-wait.R
+++ b/tests/testthat/test-wait.R
@@ -30,6 +30,10 @@ test_that("wait with timeout", {
 test_that("wait after process already exited", {
 
   px <- get_tool("px")
+  
+  pxs <- replicate(20, process$new(px, c("outln",  "foo", "outln", "bar")))
+  rm(pxs)
+
   p <- process$new(
     px, c("outln", "foo", "outln", "bar", "outln", "foobar"))
 
@@ -37,6 +41,8 @@ test_that("wait after process already exited", {
   p$wait()
 
   ## Now wait() should return immediately, regardless of timeout
+  print("1")
   expect_true(system.time(p$wait())[["elapsed"]] < 1)
+  print("2")
   expect_true(system.time(p$wait(3000))[["elapsed"]] < 1)
 })

--- a/tests/testthat/test-wait.R
+++ b/tests/testthat/test-wait.R
@@ -41,8 +41,6 @@ test_that("wait after process already exited", {
   p$wait()
 
   ## Now wait() should return immediately, regardless of timeout
-  print("1")
   expect_true(system.time(p$wait())[["elapsed"]] < 1)
-  print("2")
   expect_true(system.time(p$wait(3000))[["elapsed"]] < 1)
 })


### PR DESCRIPTION
We need proper weak references in the child list, we cannot just have a `SEXP` (any more?).

In addition, removed some dead code, that copies over pid and exit status into R. This is not needed,  because we never finalize the xptr without finalizing the R6 object, at least for now.

Plus, added some Travis magic to create core dumps, and print out their stack traces, after crashes, on Unix and macOS.
