### PR TITLE
Cleanup process tree

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,4 @@ Suggests:
     ps,
     testthat,
     withr
-Remotes:
-    r-lib/ps
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,9 @@ Suggests:
     covr,
     debugme,
     parallel,
+    ps,
     testthat,
     withr
+Remotes:
+    r-lib/ps
 Encoding: UTF-8

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -84,7 +84,15 @@ process_initialize <- function(self, private, command, args,
     private, cleanup, wd, encoding,
     paste0("PROCESSX_", private$tree_id, "=YES")
   )
-  private$starttime <- Sys.time()
+
+  ## We try the query the start time according to the OS, because we can
+  ## use the (pid, start time) pair as an id when performing operations on
+  ## the process, e.g. sending signals. This is only implemented on Linux,
+  ## macOS and Windows and on other OSes it returns 0.0, so we just use the
+  ## current time instead. (In the C process handle, there will be 0,
+  ## still.)
+  private$starttime <- .Call(c_processx__proc_start_time, private$status)
+  if (private$starttime == 0) private$starttime <- Sys.time()
 
   ## Need to close this, otherwise the child's end of the pipe
   ## will not be closed when the child exits, and then we cannot

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -74,12 +74,15 @@ process_initialize <- function(self, private, command, args,
 
   if (!is.null(env)) env <- enc2utf8(paste(names(env), sep = "=", env))
 
+  private$tree_id <- get_id()
+
   "!DEBUG process_initialize exec()"
   private$status <- .Call(
     c_processx_exec,
     command, c(command, args), stdin, stdout, stderr, connections, env,
     windows_verbatim_args, windows_hide_window,
-    private, cleanup, wd, encoding
+    private, cleanup, wd, encoding,
+    paste0("PROCESSX_", private$tree_id, "=YES")
   )
   private$starttime <- Sys.time()
 

--- a/R/on-load.R
+++ b/R/on-load.R
@@ -1,6 +1,9 @@
 
+Internal <- NULL
+
 .onLoad <- function(libname, pkgname) {
   supervisor_reset()
+  Internal <<- get(".Internal", asNamespace("base"))
   if (requireNamespace("debugme", quietly = TRUE)) debugme::debugme() # nocov
 }
 

--- a/R/process.R
+++ b/R/process.R
@@ -25,6 +25,7 @@ NULL
 #' p$signal(signal)
 #' p$interrupt()
 #' p$kill(grace = 0.1)
+#' p$kill_tree(grace = 0.1)
 #' p$wait(timeout = -1)
 #' p$get_pid()
 #' p$get_exit_status()
@@ -155,6 +156,15 @@ NULL
 #' or job object (on Windows). It returns `TRUE` if the process
 #' was killed, and `FALSE` if it was no killed (because it was
 #' already finished/dead when `processx` tried to kill it).
+#'
+#' `$kill_tree()` performs process tree cleanup, it kills the process
+#' (if still alive), together with any child (or grandchild, etc.)
+#' processes. It uses the _ps_ package, so that needs to be installed,
+#' and _ps_ needs to support the current platform as well. Process tree
+#' cleanup works by marking the process with an environment variable,
+#' which is inherited in all child processes. This allows finding
+#' descendents, even if they are orphaned, i.e. they are not connected
+#' to the root of the tree cleanup in the process tree any more.
 #'
 #' `$wait()` waits until the process finishes, or a timeout happens.
 #' Note that if the process never finishes, and the timeout is infinite
@@ -353,6 +363,9 @@ process <- R6Class(
     kill = function(grace = 0.1)
       process_kill(self, private, grace),
 
+    kill_tree = function(grace = 0.1)
+      process_kill_tree(self, private, grace),
+
     signal = function(signal)
       process_signal(self, private, signal),
 
@@ -543,6 +556,22 @@ process_interrupt <- function(self, private) {
 process_kill <- function(self, private, grace) {
   "!DEBUG process_kill '`private$get_short_name()`', pid `self$get_pid()`"
   .Call(c_processx_kill, private$status, as.numeric(grace))
+}
+
+process_kill_tree <- function(self, private, grace) {
+  "!DEBUG process_kill_tree '`private$get_short_name()`', pid `self$get_pid()`"
+  if (!requireNamespace("ps", quietly = TRUE)) {
+    stop(structure(
+      list(message = "kill_tree needs the ps package"),
+      class = c("missing_import", "error", "condition")))
+  }
+  if (!ps::ps_is_supported()) {
+    stop(structure(
+      list(message = "kill_tree is not supported on this platform"),
+      class = c("not_implemented", "error", "condition")))
+  }
+
+  get("ps_kill_tree", asNamespace("ps"))(private$tree_id)
 }
 
 process_get_start_time <- function(self, private) {

--- a/R/process.R
+++ b/R/process.R
@@ -498,6 +498,8 @@ process <- R6Class(
     post_process_result = NULL,
     post_process_done = FALSE,
 
+    tree_id = NULL,
+
     get_short_name = function()
       process_get_short_name(self, private)
   )

--- a/R/process.R
+++ b/R/process.R
@@ -546,7 +546,7 @@ process_kill <- function(self, private, grace) {
 }
 
 process_get_start_time <- function(self, private) {
-  private$starttime
+  format_unix_time(private$starttime)
 }
 
 process_get_pid <- function(self, private) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -190,3 +190,7 @@ get_id <- function() {
     collapse = ""
   )
 }
+
+format_unix_time <- function(z) {
+  structure(z, class = c("POSIXct", "POSIXt"), tzone = "GMT")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -183,3 +183,10 @@ get_tool <- function(prog) {
   }
   exe
 }
+
+get_id <- function() {
+  paste(
+    sample(c(LETTERS, 0:9), 10, replace = TRUE),
+    collapse = ""
+  )
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -185,12 +185,26 @@ get_tool <- function(prog) {
 }
 
 get_id <- function() {
-  paste(
-    sample(c(LETTERS, 0:9), 10, replace = TRUE),
-    collapse = ""
+  paste0(
+    "PS",
+    paste(sample(c(LETTERS, 0:9), 10, replace = TRUE), collapse = ""),
+    "_", as.integer(Internal(Sys.time()))
   )
 }
 
 format_unix_time <- function(z) {
   structure(z, class = c("POSIXct", "POSIXt"), tzone = "GMT")
+}
+
+r_version <- function(x) {
+  v <- paste0(version[["major"]], ".", version[["minor"]])
+  package_version(v)
+}
+
+file_size <- function(x) {
+  if (r_version() >= "3.2.0") {
+    file.info(x, extra_cols = FALSE)$size
+  } else {
+    file.info(x)$size
+  }
 }

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -24,6 +24,7 @@ p$is_alive()
 p$signal(signal)
 p$interrupt()
 p$kill(grace = 0.1)
+p$kill_tree(grace = 0.1)
 p$wait(timeout = -1)
 p$get_pid()
 p$get_exit_status()
@@ -160,6 +161,15 @@ processes, except if they have created a new process group (on Unix),
 or job object (on Windows). It returns \code{TRUE} if the process
 was killed, and \code{FALSE} if it was no killed (because it was
 already finished/dead when \code{processx} tried to kill it).
+
+\code{$kill_tree()} performs process tree cleanup, it kills the process
+(if still alive), together with any child (or grandchild, etc.)
+processes. It uses the \emph{ps} package, so that needs to be installed,
+and \emph{ps} needs to support the current platform as well. Process tree
+cleanup works by marking the process with an environment variable,
+which is inherited in all child processes. This allows finding
+descendents, even if they are orphaned, i.e. they are not connected
+to the root of the tree cleanup in the process tree any more.
 
 \code{$wait()} waits until the process finishes, or a timeout happens.
 Note that if the process never finishes, and the timeout is infinite

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,6 +1,6 @@
 
 OBJECTS = init.o poll.o processx-connection.o            \
-          processx-vector.o                              \
+          processx-vector.o create-time.o                \
 	  unix/childlist.o unix/connection.o             \
           unix/processx.o unix/sigchld.o unix/utils.o    \
 	  unix/named_pipe.o

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 OBJECTS = init.o poll.o processx-connection.o			     \
-          processx-vector.o                                          \
+          processx-vector.o create-time.o                            \
           win/processx.o win/stdio.o win/named_pipe.o win/cleanup.o  \
 	  win/iocp.o
 

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -101,7 +101,7 @@ double processx__create_time_since_boot(long pid) {
   }
   /* This removed the last character, but that's a \n anyway.
      At least we have a zero terminated string... */
-  *(buf + ret) = '\0';
+  *(buf + ret - 1) = '\0';
 
   /* Find the first '(' and last ')', that's the end of the command */
   l = strchr(buf, '(');
@@ -158,6 +158,8 @@ double processx__boot_time() {
 
   ret = processx__read_file("/proc/stat", &buf, /* buffer= */ 2048);
   if (ret < 0)  return 0.0;
+
+  *(buf + ret - 1) = '\0';
 
   btime_pos = processx__memmem(buf, ret, btime_str, btime_size);
   if (! btime_pos) return 0.0;

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -64,6 +64,7 @@ int processx__read_file(const char *path, char **buffer, size_t buffer_size) {
     rem_size -= ret;
   } while (ret > 0);
 
+  close(fd);
   return buffer_size - rem_size;
 
  error:

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -8,7 +8,7 @@
 #include <windows.h>
 
 double processx__create_time(HANDLE process) {
-  long long   unix_time;
+  long long   ll, secs, nsecs;
   FILETIME    ftCreate, ftExit, ftKernel, ftUser;
 
   if (! GetProcessTimes(process, &ftCreate, &ftExit, &ftKernel, &ftUser)) {
@@ -20,10 +20,11 @@ double processx__create_time(HANDLE process) {
     }
   }
 
-  unix_time = ((LONGLONG) ftCreate.dwHighDateTime) << 32;
-  unix_time += ftCreate.dwLowDateTime - 116444736000000000LL;
-  unix_time /= 10000000;
-  return (double) unix_time;
+  ll = ((LONGLONG) ftCreate.dwHighDateTime) << 32;
+  ll += ftCreate.dwLowDateTime - 116444736000000000LL;
+  secs = ll / 10000000;
+  nsecs = ll % 10000000;
+  return (double) secs + ((double) nsecs) / 10000000;
 }
 
 #endif

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -1,0 +1,226 @@
+
+#include <Rinternals.h>
+
+#include "processx.h"
+
+#ifdef _WIN32
+
+double processx__create_time(long pid) {
+  /* TODO */
+  return 0.0;
+}
+
+#endif
+
+#ifdef __linux__
+
+#include <sys/sysinfo.h>
+#include <unistd.h>
+
+int processx__read_file(const char *path, char **buffer, size_t buffer_size) {
+  int fd = -1;
+  ssize_t ret;
+  char *ptr;
+  size_t rem_size = buffer_size;
+
+  *buffer = 0;
+
+  fd = open(path, O_RDONLY);
+  if (fd == -1) goto error;
+
+  ptr = *buffer = R_alloc(buffer_size, 1);
+  if (!*buffer) goto error;
+
+  do {
+    if (rem_size == 0) {
+      *buffer = S_realloc(*buffer, buffer_size * 2, buffer_size, 1);
+      if (!*buffer) goto error;
+      ptr = *buffer + buffer_size;
+      rem_size = buffer_size;
+      buffer_size *= 2;
+    }
+
+    ret = read(fd, ptr, rem_size);
+    if (ret == -1) goto error;
+
+    ptr += ret;
+    rem_size -= ret;
+  } while (ret > 0);
+
+  return buffer_size - rem_size;
+
+ error:
+  if (fd >= 0) close(fd);
+  if (*buffer) free(*buffer);
+  *buffer = 0;
+  return -1;
+}
+
+double processx__create_time_since_boot(long pid) {
+  char path[512];
+  int ret;
+  char *buf;
+  char *l, *r;
+
+  char state[2] = { 0, 0 };
+  int ppid, pgrp, session, tty_nr, tpgid;
+  unsigned int flags;
+  unsigned long minflt, cminflt, majflt, cmajflt, utime, stime;
+  long int cutime, cstime, priority, nice, num_threads, itrealvalue;
+  unsigned long long starttime;
+
+  ret = snprintf(path, sizeof(path), "/proc/%d/stat", (int) pid);
+  if (ret >= sizeof(path)) {
+    warning("Cannot parse stat file, buffer too small: %s", strerror(errno));
+    return 0.0;
+  } else if (ret < 0) {
+    warning("Cannot parse stat file, buffer error: %s", strerror(errno));
+    return 0.0;
+  }
+
+  ret = processx__read_file(path, &buf, /* buffer= */ 2048);
+  if (ret == -1) {
+    warning("Cannot parse stat file, cannot read file: %s", strerror(errno));
+    return 0.0;
+  }
+  /* This removed the last character, but that's a \n anyway.
+     At least we have a zero terminated string... */
+  *(buf + ret) = '\0';
+
+  /* Find the first '(' and last ')', that's the end of the command */
+  l = strchr(buf, '(');
+  r = strrchr(buf, ')');
+  if (!l || !r) {
+    return 0.0;
+  }
+
+  *r = '\0';
+
+  ret = sscanf(r+2,
+    "%c %d %d %d %d %d %u %lu %lu %lu %lu %lu %lu %ld %ld %ld %ld %ld %ld %llu",
+    state, &ppid, &pgrp, &session, &tty_nr, &tpgid, &flags, &minflt,
+    &cminflt, &majflt, &cmajflt, &utime, &stime, &cutime, &cstime, &priority,
+    &nice, &num_threads, &itrealvalue, &starttime);
+
+  if (ret == -1) {
+    warning("Cannot parse stat file, parse error: %s", strerror(errno));
+    return 0.0;
+  } else if (ret != 20) {
+    warning("Cannot parse stat file, unknown parse error.", strerror(errno));
+    return 0.0;
+  }
+
+  return starttime;
+}
+
+void *processx__memmem(const void *haystack, size_t n1,
+		       const void *needle, size_t n2) {
+
+  const unsigned char *p1 = haystack;
+  const unsigned char *p2 = needle;
+  const unsigned char *p3 = p1 + n1 - n2 + 1;
+  const unsigned char *p;
+
+  if (n2 == 0) return (void*)p1;
+  if (n2 > n1) return NULL;
+
+  for (p = p1; (p = memchr(p, *p2, p3 - p)) != NULL; p++) {
+    if (!memcmp(p, p2, n2)) return (void*)p;
+  }
+
+  return NULL;
+}
+
+double processx__boot_time() {
+  char *buf;
+  int ret;
+  char *pos;
+  const char *btime_str = "\nbtime ";
+  size_t btime_size = 7;
+  char *btime_pos;
+  unsigned long btime;
+
+  ret = processx__read_file("/proc/stat", &buf, /* buffer= */ 2048);
+  if (ret < 0)  return 0.0;
+
+  btime_pos = processx__memmem(buf, ret, btime_str, btime_size);
+  if (! btime_pos) return 0.0;
+
+  ret = sscanf(btime_pos + btime_size, "%lu", &btime);
+  if (ret != 1) return 0.0;
+
+  return (double) btime;
+}
+
+double processx__create_time(long pid) {
+  double ct;
+  double bt;
+  double clock;
+
+  ct = processx__create_time_since_boot(pid);
+  if (ct == 0) return 0.0;
+
+  bt = processx__boot_time();
+  if (bt == 0) return 0.0;
+
+  clock = sysconf(_SC_CLK_TCK);
+
+  return bt + ct / clock;
+}
+
+#endif
+
+#ifdef __APPLE__
+
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#define PROCESSX__TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
+
+double processx__create_time(long pid) {
+  struct kinfo_proc kp;
+  int mib[4];
+  size_t len;
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PID;
+  mib[3] = (pid_t) pid;
+
+  len = sizeof(struct kinfo_proc);
+
+  if (sysctl(mib, 4, &kp, &len, NULL, 0) == -1) return 0.0;
+
+  /* Happens if process is gone already */
+  if (len == 0) return 0.0;
+
+  return PROCESSX__TV2DOUBLE(kp.kp_proc.p_starttime);
+}
+
+#endif
+
+#ifndef _WIN32
+#ifndef __linux__
+#ifndef __APPLE__
+
+double processx__create_time(long pid) {
+  return 0;
+}
+
+#endif
+#endif
+#endif
+
+SEXP processx_create_time(SEXP r_pid) {
+  return ScalarReal(processx__create_time(INTEGER(r_pid)[0]));
+}
+
+SEXP processx__proc_start_time(SEXP status) {
+  processx_handle_t *handle = R_ExternalPtrAddr(status);
+
+  if (!handle) {
+    error("Internal processx error, handle already removed");
+  }
+
+  return ScalarReal(handle->create_time);
+}

--- a/src/init.c
+++ b/src/init.c
@@ -18,6 +18,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_interrupt",          (DL_FUNC) &processx_interrupt,          1 },
   { "processx_kill",               (DL_FUNC) &processx_kill,               2 },
   { "processx_get_pid",            (DL_FUNC) &processx_get_pid,            1 },
+  { "processx_create_time",        (DL_FUNC) &processx_create_time,        1 },
   { "processx_poll",               (DL_FUNC) &processx_poll,               3 },
   { "processx__process_exists",    (DL_FUNC) &processx__process_exists,    1 },
   { "processx__killem_all",        (DL_FUNC) &processx__killem_all,        0 },
@@ -25,6 +26,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_close_named_pipe",   (DL_FUNC) &processx_close_named_pipe,   1 },
   { "processx_create_named_pipe",  (DL_FUNC) &processx_create_named_pipe,  2 },
   { "processx_write_named_pipe",   (DL_FUNC) &processx_write_named_pipe,   2 },
+  { "processx__proc_start_time",   (DL_FUNC) &processx__proc_start_time,   1 },
 
   { "processx_connection_create",     (DL_FUNC) &processx_connection_create,     2 },
   { "processx_connection_read_chars", (DL_FUNC) &processx_connection_read_chars, 2 },

--- a/src/init.c
+++ b/src/init.c
@@ -10,7 +10,7 @@ SEXP processx__killem_all();
 SEXP run_testthat_tests();
 
 static const R_CallMethodDef callMethods[]  = {
-  { "processx_exec",               (DL_FUNC) &processx_exec,              13 },
+  { "processx_exec",               (DL_FUNC) &processx_exec,              14 },
   { "processx_wait",               (DL_FUNC) &processx_wait,               2 },
   { "processx_is_alive",           (DL_FUNC) &processx_is_alive,           1 },
   { "processx_get_exit_status",    (DL_FUNC) &processx_get_exit_status,    1 },

--- a/src/processx.h
+++ b/src/processx.h
@@ -41,7 +41,7 @@ SEXP processx_exec(SEXP command, SEXP args,
 		   SEXP connections, SEXP env,
 		   SEXP windows_verbatim_args,
 		   SEXP windows_hide_window, SEXP private_, SEXP cleanup,
-		   SEXP wd, SEXP encoding);
+		   SEXP wd, SEXP encoding, SEXP tree_id);
 SEXP processx_wait(SEXP status, SEXP timeout);
 SEXP processx_is_alive(SEXP status);
 SEXP processx_get_exit_status(SEXP status);

--- a/src/processx.h
+++ b/src/processx.h
@@ -49,10 +49,12 @@ SEXP processx_signal(SEXP status, SEXP signal);
 SEXP processx_interrupt(SEXP status);
 SEXP processx_kill(SEXP status, SEXP grace);
 SEXP processx_get_pid(SEXP status);
+SEXP processx_create_time(SEXP r_pid);
 
 SEXP processx_poll(SEXP statuses, SEXP conn, SEXP ms);
 
 SEXP processx__process_exists(SEXP pid);
+SEXP processx__proc_start_time(SEXP status);
 
 SEXP processx_is_named_pipe_open(SEXP pipe_ext);
 SEXP processx_close_named_pipe(SEXP pipe_ext);

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <stdlib.h>
 
 void usage() {
   fprintf(stderr, "Usage: px [command arg] [command arg] ...\n\n");
@@ -27,6 +28,8 @@ void usage() {
 	  "write to file descriptor\n");
   fprintf(stderr, "  echo <fd1> <fd2> <nbytes>  -- "
 	  "echo from fd to another fd\n");
+  fprintf(stderr, "  getenv <var>               -- "
+	  "environment variable to stdout\n");
 }
 
 void cat2(int f, const char *s) {
@@ -161,6 +164,10 @@ int main(int argc, const char **argv) {
 	return 8;
       }
       if (echo_from_fd(fd, fd2, nbytes)) return 9;
+
+    } else if (!strcmp("getenv", cmd)) {
+      printf("%s\n", getenv(argv[++idx]));
+      fflush(stdout);
 
     } else {
       fprintf(stderr, "Unknown px command: '%s'\n", cmd);

--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -19,6 +19,7 @@ typedef struct processx_handle_s {
   int fd2;			/* readable */
   int waitpipe[2];		/* use it for wait() with timeout */
   int cleanup;
+  double create_time;
   processx_connection_t *pipes[3];
 } processx_handle_t;
 
@@ -71,5 +72,7 @@ int processx__interruptible_poll(struct pollfd fds[],
   error("%s %s at %s:%d", msg1, msg2, __FILE__,  __LINE__)
 
 void processx__make_socketpair(int pipe[2]);
+
+double processx__create_time(long pid);
 
 #endif

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -343,6 +343,10 @@ SEXP processx_exec(SEXP command, SEXP args, SEXP std_in, SEXP std_out,
     /* LCOV_EXCL_STOP */
   }
 
+  /* Query creation time ASAP. We'll use (pid, create_time) as an ID,
+     to avoid race conditions when sending signals */
+  handle->create_time = processx__create_time(pid);
+
   /* We need to know the processx children */
   if (processx__child_add(pid, result)) {
     err = -errno;

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -12,7 +12,8 @@ static void processx__child_init(processx_handle_t *handle, int (*pipes)[2],
 				 int error_fd, const char *std_in,
 				 const char *std_out,
 				 const char *std_err, char **env,
-				 processx_options_t *options);
+				 processx_options_t *options,
+				 const char *tree_id);
 
 static SEXP processx__make_handle(SEXP private, int cleanup);
 static void processx__handle_destroy(processx_handle_t *handle);
@@ -75,7 +76,8 @@ static void processx__child_init(processx_handle_t* handle, int (*pipes)[2],
 				 int error_fd, const char *std_in,
 				 const char *std_out,
 				 const char *std_err, char **env,
-				 processx_options_t *options) {
+				 processx_options_t *options,
+				 const char *tree_id) {
 
   int close_fd, use_fd, fd, i;
   const char *out_files[3] = { std_in, std_out, std_err };
@@ -152,6 +154,11 @@ static void processx__child_init(processx_handle_t* handle, int (*pipes)[2],
   }
 
   if (env) environ = env;
+
+  if (putenv(strdup(tree_id))) {
+    processx__write_int(error_fd, - errno);
+    raise(SIGKILL);
+  }
 
   execvp(command, args);
   processx__write_int(error_fd, - errno);
@@ -259,7 +266,8 @@ skip:
 SEXP processx_exec(SEXP command, SEXP args, SEXP std_in, SEXP std_out,
 		   SEXP std_err, SEXP connections, SEXP env,
 		   SEXP windows_verbatim_args, SEXP windows_hide_window,
-		   SEXP private, SEXP cleanup,  SEXP wd, SEXP encoding) {
+		   SEXP private, SEXP cleanup,  SEXP wd, SEXP encoding,
+		   SEXP tree_id) {
 
   char *ccommand = processx__tmp_string(command, 0);
   char **cargs = processx__tmp_character(args);
@@ -269,6 +277,7 @@ SEXP processx_exec(SEXP command, SEXP args, SEXP std_in, SEXP std_out,
   const char *cstdout = isNull(std_out) ? 0 : CHAR(STRING_ELT(std_out, 0));
   const char *cstderr = isNull(std_err) ? 0 : CHAR(STRING_ELT(std_err, 0));
   const char *cencoding = CHAR(STRING_ELT(encoding, 0));
+  const char *ctree_id = CHAR(STRING_ELT(tree_id, 0));
   processx_options_t options = { 0 };
   int num_connections = LENGTH(connections) + 3;
 
@@ -329,7 +338,7 @@ SEXP processx_exec(SEXP command, SEXP args, SEXP std_in, SEXP std_out,
     /* LCOV_EXCL_START */
     processx__child_init(handle, pipes, num_connections, ccommand, cargs,
 			 signal_pipe[1], cstdin, cstdout, cstderr, cenv,
-			 &options);
+			 &options, ctree_id);
     PROCESSX__ERROR("Cannot start child process", "");
     /* LCOV_EXCL_STOP */
   }

--- a/src/win/processx-win.h
+++ b/src/win/processx-win.h
@@ -39,5 +39,6 @@ void processx__error(const char *message, DWORD errorcode, const char *file, int
 
 void processx__stdio_noinherit(BYTE* buffer);
 int processx__stdio_verify(BYTE* buffer, WORD size);
+double processx__create_time(long pid);
 
 #endif

--- a/src/win/processx-win.h
+++ b/src/win/processx-win.h
@@ -13,6 +13,7 @@ typedef struct processx_handle_s {
   HANDLE waitObject;
   processx_connection_t *pipes[3];
   int cleanup;
+  double create_time;
 } processx_handle_t;
 
 int processx__utf8_to_utf16_alloc(const char* s, WCHAR** ws_ptr);
@@ -39,6 +40,6 @@ void processx__error(const char *message, DWORD errorcode, const char *file, int
 
 void processx__stdio_noinherit(BYTE* buffer);
 int processx__stdio_verify(BYTE* buffer, WORD size);
-double processx__create_time(long pid);
+double processx__create_time(HANDLE process);
 
 #endif

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -826,7 +826,8 @@ SEXP processx_exec(SEXP command, SEXP args,
 		   SEXP std_in, SEXP std_out, SEXP std_err,
 		   SEXP connections, SEXP env,
 		   SEXP windows_verbatim_args, SEXP windows_hide,
-		   SEXP private, SEXP cleanup, SEXP wd, SEXP encoding) {
+		   SEXP private, SEXP cleanup, SEXP wd, SEXP encoding,
+		   SEXP tree_id) {
 
   const char *cstd_in = isNull(std_in) ? 0 : CHAR(STRING_ELT(std_in, 0));
   const char *cstd_out = isNull(std_out) ? 0 : CHAR(STRING_ELT(std_out, 0));

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -336,6 +336,44 @@ static int qsort_wcscmp(const void *a, const void *b) {
 }
 
 static int processx__add_tree_id_env(const char *ctree_id, WCHAR **dst_ptr) {
+  WCHAR *env = GetEnvironmentStringsW();
+  int len = 0, len2 = 0;
+  WCHAR *ptr = env;
+  WCHAR *id = 0;
+  int err;
+  int idlen;
+  WCHAR *dst_copy;
+
+  if (!env) return GetLastError();
+
+  err = processx__utf8_to_utf16_alloc(ctree_id, &id);
+  if (err) {
+    FreeEnvironmentStringsW(env);
+    return(err);
+  }
+
+  while (1) {
+    WCHAR *prev = ptr;
+    if (!*ptr) break;
+    while (*ptr) ptr++;
+    ptr++;
+    len += (ptr - prev);
+  }
+
+  /* Plus the id */
+  idlen = wcslen(id) + 1;
+  len2 = len + idlen;
+
+  /* Allocate, copy */
+  dst_copy = (WCHAR*) R_alloc(len2 + 1, sizeof(WCHAR)); /* +1 for final zero */
+  memcpy(dst_copy, env, len * sizeof(WCHAR));
+  memcpy(dst_copy + len, id, idlen * sizeof(WCHAR));
+
+  /* Final \0 */
+  *(dst_copy + len2) = L'\0';
+  *dst_ptr = dst_copy;
+
+  FreeEnvironmentStringsW(env);
   return 0;
 }
 

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -1041,6 +1041,11 @@ SEXP processx_exec(SEXP command, SEXP args,
   handle->hProcess = info.hProcess;
   handle->dwProcessId = info.dwProcessId;
 
+  /* Query official creation time. On Windows this is not used as
+     an id, since the pid itself is valid until the process handle
+     is released. */
+  handle->create_time = processx__create_time(handle->hProcess);
+
   /* If the process isn't spawned as detached, assign to the global job */
   /* object so windows will kill it when the parent process dies. */
   if (ccleanup) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -11,6 +11,11 @@ skip_extra_tests <- function() {
   if (Sys.getenv("PROCESSX_EXTRA_TESTS") ==  "") skip("no extra tests")
 }
 
+skip_if_no_ps <- function() {
+  if (!requireNamespace("ps", quietly = TRUE)) skip("ps package needed")
+  if (!ps::ps_is_supported()) skip("ps does not support this platform")
+}
+
 try_silently <- function(expr) {
   tryCatch(
     expr,

--- a/tests/testthat/test-kill-tree.R
+++ b/tests/testthat/test-kill-tree.R
@@ -3,6 +3,8 @@ context("kill_tree")
 
 test_that("tree ids are inherited", {
   skip_on_cran()
+  skip_if_no_ps()
+
   px <- get_tool("px")
 
   p <- process$new(px, c("sleep", "10"))
@@ -15,6 +17,8 @@ test_that("tree ids are inherited", {
 
 test_that("tree ids are inherited if env is specified", {
   skip_on_cran()
+  skip_if_no_ps()
+
   px <- get_tool("px")
 
   p <- process$new(px, c("sleep", "10"), env = c(FOO = "bar"))
@@ -25,4 +29,87 @@ test_that("tree ids are inherited if env is specified", {
   ev <- paste0("PROCESSX_", get_private(p)$tree_id)
   expect_equal(ps::ps_environ(ep)[[ev]], "YES")
   expect_equal(ps::ps_environ(ep)[["FOO"]], "bar")
+})
+
+test_that("kill_tree", {
+  skip_on_cran()
+  skip_if_no_ps()
+
+  px <- get_tool("px")
+  p <- process$new(px, c("sleep", "100"))
+  on.exit(p$kill(), add = TRUE)
+
+  res <- p$kill_tree()
+  expect_true(any(c("px", "px.exe") %in% names(res)))
+  expect_true(p$get_pid() %in% res)
+
+  deadline <- Sys.time() + 1
+  while (p$is_alive() && Sys.time() < deadline) Sys.sleep(0.05)
+  expect_true(Sys.time() < deadline)
+  expect_false(p$is_alive())
+})
+
+test_that("kill_tree with children", {
+  skip_on_cran()
+  skip_if_no_ps()
+
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  p <- callr::r_bg(
+    function(px, tmp) {
+      processx::run(px, c("outln", "ok", "sleep", "100"),
+        stdout_callback = function(x, p) cat(x, file = tmp, append = TRUE))
+    },
+    args = list(px = get_tool("px"), tmp = tmp)
+  )
+
+  deadline <- Sys.time() + 2
+  while (!file.exists(tmp) && Sys.time() < deadline) Sys.sleep(0.05)
+  expect_true(Sys.time() < deadline)
+
+  res <- p$kill_tree()
+  expect_true(any(c("px", "px.exe") %in% names(res)))
+  expect_true(any(c("R", "Rterm.exe") %in% names(res)))
+  expect_true(p$get_pid() %in% res)
+
+  deadline <- Sys.time() + 1
+  while (p$is_alive() && Sys.time() < deadline) Sys.sleep(0.05)
+  expect_true(Sys.time() < deadline)
+  expect_false(p$is_alive())
+})
+
+test_that("kill_tree and orphaned children", {
+  skip_on_cran()
+  skip_if_no_ps()
+
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  p1 <- callr::r_bg(
+    function(px, tmp) {
+      p <- processx::process$new(px, c("outln", "ok", "sleep", "100"),
+        stdout = tmp, cleanup = FALSE)
+      list(pid = p$get_pid(), create_time = p$get_start_time(),
+           id = p$.__enclos_env__$private$tree_id)
+    },
+    args = list(px = get_tool("px"), tmp = tmp)
+  )
+
+  p1$wait()
+  pres <- p1$get_result()
+
+  ps <- ps::ps_handle(pres$pid, pres$create_time)
+  expect_true(ps::ps_is_running(ps))
+
+  deadline <- Sys.time() + 2
+  while ((!file.exists(tmp) || file_size(tmp) == 0) &&
+         Sys.time() < deadline) Sys.sleep(0.05)
+  expect_true(Sys.time() < deadline)
+
+  res <- p1$kill_tree(pres$id)
+  expect_true(any(c("px", "px.exe") %in% names(res)))
+
+  deadline <- Sys.time() + 1
+  while (ps::ps_is_running(ps) && Sys.time() < deadline) Sys.sleep(0.05)
+  expect_true(Sys.time() < deadline)
+  expect_false(ps::ps_is_running(ps))
 })

--- a/tests/testthat/test-kill-tree.R
+++ b/tests/testthat/test-kill-tree.R
@@ -1,0 +1,28 @@
+
+context("kill_tree")
+
+test_that("tree ids are inherited", {
+  skip_on_cran()
+  px <- get_tool("px")
+
+  p <- process$new(px, c("sleep", "10"))
+  on.exit(p$kill(), add = TRUE)
+  ep <- ps::process(p$get_pid())
+
+  ev <- paste0("PROCESSX_", get_private(p)$tree_id)
+  expect_equal(ep$environ()[[ev]], "YES")
+})
+
+test_that("tree ids are inherited if env is specified", {
+  skip_on_cran()
+  px <- get_tool("px")
+
+  p <- process$new(px, c("sleep", "10"), env = c(FOO = "bar"))
+  on.exit(p$kill(), add = TRUE)
+
+  ep <-  ps::process(p$get_pid())
+
+  ev <- paste0("PROCESSX_", get_private(p)$tree_id)
+  expect_equal(ep$environ()[[ev]], "YES")
+  expect_equal(ep$environ()[["FOO"]], "bar")
+})

--- a/tests/testthat/test-kill-tree.R
+++ b/tests/testthat/test-kill-tree.R
@@ -7,10 +7,10 @@ test_that("tree ids are inherited", {
 
   p <- process$new(px, c("sleep", "10"))
   on.exit(p$kill(), add = TRUE)
-  ep <- ps::process(p$get_pid())
+  ep <- ps::ps_handle(p$get_pid())
 
   ev <- paste0("PROCESSX_", get_private(p)$tree_id)
-  expect_equal(ep$environ()[[ev]], "YES")
+  expect_equal(ps::ps_environ(ep)[[ev]], "YES")
 })
 
 test_that("tree ids are inherited if env is specified", {
@@ -20,9 +20,9 @@ test_that("tree ids are inherited if env is specified", {
   p <- process$new(px, c("sleep", "10"), env = c(FOO = "bar"))
   on.exit(p$kill(), add = TRUE)
 
-  ep <-  ps::process(p$get_pid())
+  ep <-  ps::ps_handle(p$get_pid())
 
   ev <- paste0("PROCESSX_", get_private(p)$tree_id)
-  expect_equal(ep$environ()[[ev]], "YES")
-  expect_equal(ep$environ()[["FOO"]], "bar")
+  expect_equal(ps::ps_environ(ep)[[ev]], "YES")
+  expect_equal(ps::ps_environ(ep)[["FOO"]], "bar")
 })


### PR DESCRIPTION
Every processx process `p` is marked with an environment variable that has a random part and a time stamp. Importantly, this variable is _not_ set  in the current process, that would lead to having it set in other, non-processx child processes, eg. started by RStudio.

This env var is then inherited by all processes in the process tree rooted at `p`, even if some processes  in the tree are orphaned. (In theory processes could opt out and unset the env var, but we don't anticipate this happening very often.)

`kill_tree()` uses this  env var, and the (internal) ps package function `ps_kill_tree` to clean up the whole tree.

Closes #139.