### PR TITLE
Work around IOCP crash by marking the key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # dev
 
+* Fix a crash on Windows, when polling and R or another package creates
+  an IOCP from the main R thread (#184).
+
 # processx 3.3.0
 
 * `process` can now redirect the standard error to the standard output, via

--- a/src/processx-connection.h
+++ b/src/processx-connection.h
@@ -43,6 +43,7 @@ typedef enum {
 } processx_file_type_t;
 
 typedef struct processx_connection_s {
+  int marker;
   processx_file_type_t type;
 
   int is_closed_;

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -54,6 +54,7 @@ test_that("post processing", {
 test_that("working directory", {
   px  <- get_tool("px")
   dir.create(tmp <- tempfile())
+  tmp <- normalizePath(tmp)
   on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
   cat("foo\nbar\n", file = file.path(tmp, "file"))
 


### PR DESCRIPTION
processx uses IOCPs to implement poll() on Windows.
One trouble with IOCPs is that on thread can only be
associated with one IOCP. If you create another IOCP
while the previous one is still active, the result
is apparently a mess.

R-devel uses IOCPs now,
https://github.com/wch/r-source/commit/fd4545643221862555559da9f296e3f996bfc567
which is a problem for processx.

The proper solution is to do all processx poll/read
in another thread. However this is a quick fix that
at least avoids some crashes. This fix simply ignores
async reads that were not started by processx.

It works by marking all processx connections with a
random integer as the first element of the struct.
After an async read completes, we check if it has the
marker, and if not we simply ignore it.

This fixes #184.