### PR TITLE
Better printing of run() errors

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(close,processx_connection)
 S3method(close_named_pipe,unix_named_pipe)
 S3method(close_named_pipe,windows_named_pipe)
+S3method(conditionMessage,system_command_status_error)
 S3method(conn_is_incomplete,processx_connection)
 S3method(conn_read_chars,processx_connection)
 S3method(conn_read_lines,processx_connection)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # processx dev
 
+* `run()` now prints the last 10 lines of the standard error stream on
+  error, if `echo = FALSE`.
+
 # processx 3.3.1
 
 * Fix a crash on Windows, when a connection that has a pending read

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -1,0 +1,43 @@
+
+context("errors")
+
+test_that("run() prints stderr if echo = FALSE", {
+  px <- get_tool("px")
+  err <- tryCatch(
+    run(px, c("outln", "nopppp", "errln", "bad", "errln", "foobar",
+              "return", "2")),
+    error = function(e) e)
+  expect_match(conditionMessage(err), "foobar")
+  expect_false(any(grepl("nopppp", conditionMessage(err))))
+})
+
+test_that("run() omits stderr if echo = TRUE", {
+  px <- get_tool("px")
+  err <- tryCatch(
+    capture.output(
+      run(px, c("errln", "bad", "errln", "foobar", "return", "2"),
+          echo = TRUE)),
+    error = function(e) e)
+  expect_false(any(grepl("foobar", conditionMessage(err))))
+})
+
+test_that("run() handles stderr_to_stdout = TRUE properly", {
+  px <- get_tool("px")
+  err <- tryCatch(
+    run(px, c("outln", "nopppp", "errln", "bad", "errln", "foobar",
+              "return", "2"), stderr_to_stdout = TRUE),
+    error = function(e) e)
+  expect_match(conditionMessage(err), "foobar")
+  expect_match(conditionMessage(err), "nopppp")
+})
+
+test_that("run() only prints the last 10 lines of stderr", {
+  px <- get_tool("px")
+  args <- rbind("errln", paste0("foobar", 1:11, "--"))
+  err <- tryCatch(
+    run(px, c(args, "return", "2")),
+    error = function(e) e)
+  expect_false(any(grepl("foobar1--", conditionMessage(err))))
+  expect_match(conditionMessage(err), "foobar2--")
+  expect_match(conditionMessage(err), "foobar11--")
+})


### PR DESCRIPTION
1. If echo = FALSE, then we print the last 10 lines of
   stderr.
2. If stderr_to_stdout = TRUE, then the last 10 lines
   of stdout + stderr.
3. echo = TRUE, then we do not print them again.

Closes #195.