### PR TITLE
Define _GNU_SOURCE on Unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ pandoc: false
 
 matrix:
   include:
-    - r: 3.1
     - r: 3.2
     - r: 3.3
     - r: 3.4
+    - r: 3.5
     - r: release
       env: R_CODECOV=true
     - r: devel

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,4 +1,8 @@
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #include <Rinternals.h>
 #include <string.h>
 

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -1,4 +1,8 @@
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #include <Rinternals.h>
 
 #include "processx.h"

--- a/src/errors.h
+++ b/src/errors.h
@@ -2,6 +2,10 @@
 #ifndef R_THROW_ERROR_H
 #define R_THROW_ERROR_H
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #else

--- a/src/processx-connection.h
+++ b/src/processx-connection.h
@@ -2,6 +2,10 @@
 #ifndef PROCESSX_CONNECTION_H
 #define PROCESSX_CONNECTION_H
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #ifdef __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L

--- a/src/processx-vector.c
+++ b/src/processx-vector.c
@@ -1,4 +1,8 @@
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #include <R.h>
 #include "processx-types.h"
 #include "errors.h"

--- a/src/processx.h
+++ b/src/processx.h
@@ -6,6 +6,10 @@
 extern "C" {
 #endif
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #ifdef __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L

--- a/src/tools/px.c
+++ b/src/tools/px.c
@@ -1,4 +1,8 @@
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #if defined __INTEL_COMPILER
 #define _BSD_SOURCE 1
 #define _POSIX_C_SOURCE  200809L

--- a/src/unix/named_pipe.c
+++ b/src/unix/named_pipe.c
@@ -3,6 +3,10 @@
 
 #ifndef _WIN32
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
 #include <Rdefines.h>
 
 #include "../errors.h"

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -1,11 +1,8 @@
 
 #ifndef _WIN32
 
-#if ! defined(__sun)
-        /* Prevents ptsname() declaration being visible on Solaris 8 */
-#if ! defined(_XOPEN_SOURCE) || _XOPEN_SOURCE < 600
-#define _XOPEN_SOURCE 600
-#endif
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
Otherwise not all POSIX features are defined on
some compilers, notably icc has problems.