### PR TITLE
Notify parallel (or other pkg) about SIGCHLD

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 * Fix a SIGPIPE crash when trying to write to the subprocess that has
   exited already.
 
+* processx now to works better with fork clusters from the parallel
+  package. See TODO for details (#236).
+
 # processx 3.4.1
 
 * Now `run()` does not create an `ok` variable in the global environment.

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,6 +47,7 @@ facilities, with a timeout.
          * [Polling multiple processes](#polling-multiple-processes)
          * [Waiting on a process](#waiting-on-a-process)
          * [Exit statuses](#exit-statuses)
+         * [Mixing processx and the parallel base R package](#mixing-processx-and-the-parallel-base-r-package)
          * [Errors](#errors-1)
    * [Related tools](#related-tools)
    * [Code of Conduct](#code-of-conduct)
@@ -399,6 +400,20 @@ p$get_exit_status()
 p$wait()
 p$get_exit_status()
 ```
+
+#### Mixing processx and the parallel base R package
+
+In general, mixing processx (via callr or not) and parallel works fine.
+If you use parallel's 'fork' clusters, e.g. via `parallel::mcparallel()`,
+then you might see two issues. One is that processx will not be able to
+determine the exit status of some processx processes. This is because the
+status is read out by parallel, and processx will set it to `NA`. The other
+one is that parallel might complain that it could not clean up some
+subprocesses. This is not an error, and it is harmless, but it does
+hold up R for about 10 seconds, before parallel gives up. To work around
+this, you can set the `PROCESSX_NOTIFY_OLD_SIGCHLD` environment variable
+to a non-empty value, before you load processx. This behavior might be
+the default in the future.
 
 #### Errors
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ facilities, with a timeout.
          * [Polling multiple processes](#polling-multiple-processes)
          * [Waiting on a process](#waiting-on-a-process)
          * [Exit statuses](#exit-statuses)
+         * [Mixing processx and the parallel base R package](#mixing-processx-and-the-parallel-base-r-package)
          * [Errors](#errors-1)
    * [Related tools](#related-tools)
    * [Code of Conduct](#code-of-conduct)
@@ -657,6 +658,20 @@ p$get_exit_status()
 ```
 #> [1] 0
 ```
+
+#### Mixing processx and the parallel base R package
+
+In general, mixing processx (via callr or not) and parallel works fine.
+If you use parallel's 'fork' clusters, e.g. via `parallel::mcparallel()`,
+then you might see two issues. One is that processx will not be able to
+determine the exit status of some processx processes. This is because the
+status is read out by parallel, and processx will set it to `NA`. The other
+one is that parallel might complain that it could not clean up some
+subprocesses. This is not an error, and it is harmless, but it does
+hold up R for about 10 seconds, before parallel gives up. To work around
+this, you can set the `PROCESSX_NOTIFY_OLD_SIGCHLD` environment variable
+to a non-empty value, before you load processx. This behavior might be
+the default in the future.
 
 #### Errors
 

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -57,6 +57,8 @@ extern processx__child_list_t *child_list;
 extern processx__child_list_t child_free_list_head;
 extern processx__child_list_t *child_free_list;
 
+extern int processx__notify_old_sigchld_handler;
+
 /* We are trying to make sure that the variables in the library are
    properly set to their initial values after a library (re)load.
    This function is called from `R_init_processx`. */
@@ -71,6 +73,10 @@ void R_init_processx_unix() {
   child_free_list_head.weak_status = R_NilValue;
   child_free_list_head.next = 0;
   child_free_list = &child_free_list_head;
+
+  if (getenv("PROCESSX_NOTIFY_OLD_SIGCHLD")) {
+    processx__notify_old_sigchld_handler = 1;
+  }
 }
 
 int processx__pty_master_open(char *slave_name, size_t sn_len) {

--- a/tests/testthat/test-sigchld.R
+++ b/tests/testthat/test-sigchld.R
@@ -107,8 +107,9 @@ test_that("signal", {
     list(signal = signal, status = status)
   })
 
-  # TRUE means that that signal was delivered
-  expect_true(res$result$signal)
+  # TRUE means that that signal was delivered, but it is different on
+  # various Unix flavours. Some will deliver a SIGINT to a zombie, some
+  # will not, so we don't test for this.
   expect_true(res$result$status %in% c(0L, NA_integer_))
 })
 

--- a/tests/testthat/test-sigchld.R
+++ b/tests/testthat/test-sigchld.R
@@ -112,3 +112,80 @@ test_that("SIGCHLD handler", {
 
   expect_true(px$get_exit_status() %in% c(0L, NA_integer_))
 })
+
+test_that("Notify old signal handler", {
+  skip_on_cran()
+  skip_other_platforms("unix")
+
+  code <- substitute({
+    # Create cluster, check that it works
+    cl <- parallel::makeForkCluster(2)
+    parallel::mclapply(1:2, function(x) x)
+
+    # Run a parallel background job
+    job <- parallel::mcparallel(Sys.sleep(.5))
+
+    # Start processx process, it will overwrite the signal handler
+    processx::run("true")
+
+    # Wait for parallel job to finish
+    parallel::mccollect(job)
+  })
+
+  script <- tempfile(pattern = "processx-test-", fileext = ".R")
+  on.exit(unlink(script), add = TRUE)
+  cat(deparse(code), sep = "\n", file = script)
+
+  env <- c(callr::rcmd_safe_env(), PROCESSX_NOTIFY_OLD_SIGCHLD = "true")
+  ret <- callr::rscript(
+    script,
+    env = env,
+    fail_on_status = FALSE,
+    show = FALSE,
+    timeout = 5
+  )
+
+  # parallel sends a message to stderr, complaining about unable to
+  # to terminate some child processes. That should not happen any more.
+  expect_equal(ret$stderr, "")
+})
+
+test_that("it is ok if parallel has no active cluster", {
+  skip_on_cran()
+  skip_other_platforms("unix")
+
+  code <- substitute({
+    cl <- parallel::makeForkCluster(2)
+    parallel::mclapply(1:2, function(x) x)
+
+    job <- parallel::mcparallel(Sys.sleep(.5))
+    processx::run("true")
+    parallel::mccollect(job)
+
+    # stop cluster, verify that we don't have subprocesses
+    parallel::stopCluster(cl)
+    print(ps::ps_children(ps::ps_handle()))
+
+    # try to run sg, this still calls the old sigchld handler
+    for (i in 1:5) processx::run("true")
+
+    # No cluster, just to clarify
+    print(parallel::getDefaultCluster())
+  })
+
+  script <- tempfile(pattern = "processx-test-", fileext = ".R")
+  on.exit(unlink(script), add = TRUE)
+  cat(deparse(code), sep = "\n", file = script)
+
+  env <- c(callr::rcmd_safe_env(), PROCESSX_NOTIFY_OLD_SIGCHLD = "true")
+  ret <- callr::rscript(
+    script,
+    env = env,
+    fail_on_status = FALSE,
+    show = FALSE
+  )
+
+  expect_equal(ret$status, 0)
+  expect_match(ret$stdout, "list()")
+  expect_match(ret$stdout, "NULL")
+})


### PR DESCRIPTION
This is now opt in, and the PROCESSX_NOTIFY_OLD_SIGCHLD
env var has to be set (to any value), at the time of
_loading_ of the processx package.

Fixes #236.