### PR TITLE
Use cleancall to solve a file descriptor leak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@
 * processx now does no block SIGCHLD by default in the subprocess,
   blocking potentially causes zombie sub-subprocesses (#240).
 
+* The `process$wait()` method now does not leak file descriptors on
+  Unix when interrupted (#141).
+
 # processx 3.4.1
 
 * Now `run()` does not create an `ok` variable in the global environment.

--- a/R/cleancall.R
+++ b/R/cleancall.R
@@ -1,0 +1,4 @@
+
+call_with_cleanup <- function(ptr, ...) {
+  .Call(c_cleancall_call, pairlist(ptr, ...), parent.frame())
+}

--- a/R/errors.R
+++ b/R/errors.R
@@ -78,6 +78,8 @@
 # * Update wording of error printout to be less intimidating, avoid jargon
 # * Use default printing in interactive mode, so RStudio can detect the
 #   error and highlight it.
+# * Add the rethrow_call_with_cleanup function, to work with embedded
+#   cleancall.
 
 err <- local({
 
@@ -364,6 +366,18 @@ err <- local({
   }
 
   package_env <- topenv()
+
+  #' Version of rethrow_call that supports cleancall
+  #'
+  #' This function is the same as [rethrow_call()], except that it
+  #' uses cleancall's [.Call()] wrapper, to enable resource cleanup.
+  #' See https://github.com/r-lib/cleancall#readme for more about
+  #' resource cleanup.
+  #'
+  #' @noRd
+  #' @param .NAME Compiled function to call, see [.Call()].
+  #' @param ... Function arguments, see [.Call()].
+  #' @return Result of the call.
 
   rethrow_call_with_cleanup <- function(.NAME, ...) {
     call <- sys.call()

--- a/R/process.R
+++ b/R/process.R
@@ -649,8 +649,11 @@ process <- R6::R6Class(
 
 process_wait <- function(self, private, timeout) {
   "!DEBUG process_wait `private$get_short_name()`"
-  rethrow_call(c_processx_wait, private$status, as.integer(timeout),
-               private$get_short_name())
+  rethrow_call_with_cleanup(
+    c_processx_wait, private$status,
+    as.integer(timeout),
+    private$get_short_name()
+  )
   invisible(self)
 }
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -4,7 +4,7 @@ OBJECTS = init.o poll.o errors.o processx-connection.o   \
           processx-vector.o create-time.o base64.o       \
 	  unix/childlist.o unix/connection.o             \
           unix/processx.o unix/sigchld.o unix/utils.o    \
-	  unix/named_pipe.o
+	  unix/named_pipe.o cleancall.o
 
 .PHONY: all clean
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -3,7 +3,7 @@
 OBJECTS = init.o poll.o errors.o processx-connection.o		     \
           processx-vector.o create-time.o base64.o                   \
           win/processx.o win/stdio.o win/named_pipe.o                \
-	  win/utils.o win/thread.o
+	  win/utils.o win/thread.o cleancall.o
 
 .PHONY: all clean
 

--- a/src/cleancall.c
+++ b/src/cleancall.c
@@ -1,0 +1,164 @@
+#define R_NO_REMAP
+#include <Rinternals.h>
+
+#include "cleancall.h"
+
+
+#if (defined(R_VERSION) && R_VERSION < R_Version(3, 4, 0))
+ SEXP R_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot) {
+   fn_ptr ptr;
+   ptr.fn = p;
+   return R_MakeExternalPtr(ptr.p, tag, prot);
+ }
+ DL_FUNC R_ExternalPtrAddrFn(SEXP s) {
+   fn_ptr ptr;
+   ptr.p = EXTPTR_PTR(s);
+   return ptr.fn;
+ }
+#endif
+
+// The R API does not have a setter for function pointers
+
+SEXP cleancall_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot) {
+    fn_ptr tmp;
+    tmp.fn = p;
+    return R_MakeExternalPtr(tmp.p, tag, prot);
+}
+
+void cleancall_SetExternalPtrAddrFn(SEXP s, DL_FUNC p) {
+    fn_ptr ptr;
+    ptr.fn = p;
+    R_SetExternalPtrAddr(s, ptr.p);
+}
+
+
+// Initialised at load time with the `.Call` primitive
+SEXP cleancall_fns_dot_call = NULL;
+
+void cleancall_init() {
+  cleancall_fns_dot_call = Rf_findVar(Rf_install(".Call"), R_BaseEnv);
+}
+
+struct eval_args {
+  SEXP call;
+  SEXP env;
+};
+
+static SEXP eval_wrap(void* data) {
+  struct eval_args* args = (struct eval_args*) data;
+  return Rf_eval(args->call, args->env);
+}
+
+
+SEXP cleancall_call(SEXP args, SEXP env) {
+  SEXP call = PROTECT(Rf_lcons(cleancall_fns_dot_call, args));
+  struct eval_args data = { call, env };
+
+  SEXP out = r_with_cleanup_context(&eval_wrap, &data);
+
+  UNPROTECT(1);
+  return out;
+}
+
+
+static SEXP callbacks = NULL;
+
+// Preallocate a callback
+static void push_callback(SEXP stack) {
+  SEXP top = CDR(stack);
+
+  SEXP early_handler = PROTECT(Rf_allocVector(LGLSXP, 1));
+  SEXP fn_extptr = PROTECT(cleancall_MakeExternalPtrFn(NULL, R_NilValue,
+                                                       R_NilValue));
+  SEXP data_extptr = PROTECT(R_MakeExternalPtr(NULL, early_handler,
+                                               R_NilValue));
+  SEXP cb = Rf_cons(Rf_cons(fn_extptr, data_extptr), top);
+
+  SETCDR(stack, cb);
+
+  UNPROTECT(3);
+}
+
+struct data_wrapper {
+  SEXP (*fn)(void* data);
+  void *data;
+  SEXP callbacks;
+  int success;
+};
+
+static void call_exits(void* data) {
+  // Remove protecting node. Don't remove the preallocated callback on
+  // the top as it might contain a handler when something went wrong.
+  SEXP top = CDR(callbacks);
+
+  // Restore old stack
+  struct data_wrapper* state = data;
+  callbacks = (SEXP) state->callbacks;
+
+  // Handlers should not jump
+  while (top != R_NilValue) {
+    SEXP cb = CAR(top);
+    top = CDR(top);
+
+    void (*fn)(void*) = (void (*)(void*)) R_ExternalPtrAddrFn(CAR(cb));
+    void *data = (void*) EXTPTR_PTR(CDR(cb));
+    int early_handler = LOGICAL(EXTPTR_TAG(CDR(cb)))[0];
+
+    // Check for empty pointer in preallocated callbacks
+    if (fn) {
+      if (!early_handler || !state->success) fn(data);
+    }
+  }
+}
+
+static SEXP with_cleanup_context_wrap(void *data) {
+  struct data_wrapper* cdata = data;
+  SEXP ret = cdata->fn(cdata->data);
+  cdata->success = 1;
+  return ret;
+}
+
+SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data) {
+  // Preallocate new stack before changing `callbacks` to avoid
+  // leaving the global variable in a bad state if alloc fails
+  SEXP new = PROTECT(Rf_cons(R_NilValue, R_NilValue));
+  push_callback(new);
+
+  SEXP old = callbacks;
+  callbacks = new;
+
+  struct data_wrapper state = { fn, data, old, 0 };
+
+  SEXP out = R_ExecWithCleanup(with_cleanup_context_wrap, &state,
+                               &call_exits, &state);
+
+  UNPROTECT(1);
+  return out;
+}
+
+static void call_save_handler(void (*fn)(void *data), void* data,
+                              int early) {
+  if (!callbacks) {
+    fn(data);
+    Rf_error("Internal error: Exit handler pushed outside "
+             "of an exit context");
+  }
+
+  SEXP cb = CADR(callbacks);
+
+  // Update pointers
+  cleancall_SetExternalPtrAddrFn(CAR(cb), (DL_FUNC) fn);
+  R_SetExternalPtrAddr(CDR(cb), data);
+  LOGICAL(EXTPTR_TAG(CDR(cb)))[0] = early;
+
+  // Preallocate the next callback in case the allocator jumps
+  push_callback(callbacks);
+}
+
+void r_call_on_exit(void (*fn)(void* data), void* data) {
+  call_save_handler(fn, data, /* early = */ 0);
+}
+
+void r_call_on_early_exit(void (*fn)(void* data), void* data) {
+  call_save_handler(fn, data, /* early = */ 1);
+}

--- a/src/cleancall.h
+++ b/src/cleancall.h
@@ -1,0 +1,41 @@
+#ifndef CLEANCALL_H
+#define CLEANCALL_H
+
+#include <Rversion.h>
+#include <R_ext/Rdynload.h>
+
+// --------------------------------------------------------------------
+// Internals
+// --------------------------------------------------------------------
+
+typedef union {void* p; DL_FUNC fn;} fn_ptr;
+
+#if (defined(R_VERSION) && R_VERSION < R_Version(3, 4, 0))
+ SEXP R_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot);
+ DL_FUNC R_ExternalPtrAddrFn(SEXP s);
+#endif
+
+// --------------------------------------------------------------------
+// API for packages that embed cleancall
+// --------------------------------------------------------------------
+
+// The R API does not have a setter for external function pointers
+SEXP cleancall_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot);
+void cleancall_SetExternalPtrAddrFn(SEXP s, DL_FUNC p);
+
+#define CLEANCALL_METHOD_RECORD  \
+  {"cleancall_call", (DL_FUNC) &cleancall_call, 2}
+
+SEXP cleancall_call(SEXP args, SEXP env);
+extern SEXP cleancall_fns_dot_call;
+void cleancall_init();
+
+// --------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------
+
+SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data);
+void r_call_on_exit(void (*fn)(void* data), void* data);
+void r_call_on_early_exit(void (*fn)(void* data), void* data);
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -1,5 +1,6 @@
 
 #include "processx.h"
+#include "cleancall.h"
 
 #include <R_ext/Rdynload.h>
 #include <R.h>
@@ -12,6 +13,7 @@ SEXP processx__echo_on();
 SEXP processx__echo_off();
 
 static const R_CallMethodDef callMethods[]  = {
+  CLEANCALL_METHOD_RECORD,
   { "processx_exec",               (DL_FUNC) &processx_exec,              16 },
   { "processx_wait",               (DL_FUNC) &processx_wait,               3 },
   { "processx_is_alive",           (DL_FUNC) &processx_is_alive,           2 },
@@ -62,6 +64,7 @@ void R_init_processx(DllInfo *dll) {
   R_registerRoutines(dll, NULL, callMethods, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
   R_forceSymbols(dll, TRUE);
+  cleancall_fns_dot_call = Rf_findVar(Rf_install(".Call"), R_BaseEnv);
 #ifdef _WIN32
   R_init_processx_win();
 #else


### PR DESCRIPTION
We can use it for better resource cleanup in general.