### PR TITLE
Unblock SIGCHLD in the child process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
   package. See 'Mixing processx and the parallel base R package' in the
   README file (#236).
 
+* processx now does no block SIGCHLD by default in the subprocess,
+  blocking potentially causes zombie sub-subprocesses (#240).
+
 # processx 3.4.1
 
 * Now `run()` does not create an `ok` variable in the global environment.

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -502,6 +502,7 @@ SEXP processx_exec(SEXP command, SEXP args, SEXP std_in, SEXP std_out,
   if (pid == 0) {
     /* LCOV_EXCL_START */
     if (cpty) close(pty_master_fd);
+    processx__unblock_sigchld();
     processx__child_init(handle, pipes, num_connections, ccommand, cargs,
 			 signal_pipe[1], cstdin, cstdout, cstderr,
                          pty_name, cenv, &options, ctree_id);


### PR DESCRIPTION
Because this is apparently not reset in execve().

Fixes #240.