### PR TITLE
Allow using errno on Windows

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -3,9 +3,7 @@
 
 #include <Rinternals.h>
 
-#ifndef _WIN32
 #include <string.h>
-#endif
 
 #define ERRORBUF_SIZE 4096
 static char errorbuf[ERRORBUF_SIZE];
@@ -56,9 +54,14 @@ SEXP r_throw_system_error(const char *func, const char *filename, int line,
   return R_NilValue;
 }
 
-#else
+#endif
 
-SEXP r_throw_system_error(const char *func, const char *filename, int line,
+#ifdef _WIN32
+SEXP r_throw_posix_error(
+#else
+SEXP r_throw_system_error(
+#endif
+                          const char *func, const char *filename, int line,
                           int errorcode, const char *sysmsg,
                           const char *msg, ...) {
   va_list args;
@@ -70,5 +73,3 @@ SEXP r_throw_system_error(const char *func, const char *filename, int line,
         filename, line, func);
   return R_NilValue;
 }
-
-#endif

--- a/src/errors.h
+++ b/src/errors.h
@@ -31,6 +31,16 @@ SEXP r_throw_system_error(const char *func, const char *filename, int line,
                           DWORD errorcode, const char *sysmsg,
                           const char *msg, ...);
 
+SEXP r_throw_posix_error(const char *func, const char *filename, int line,
+                         int errorcode, const char *sysmsg,
+                         const char *msg, ...);
+
+#define R_THROW_POSIX_ERROR(...)                                        \
+  r_throw_posix_error(__func__, __FILE__, __LINE__, errno, NULL, __VA_ARGS__)
+#define R_THROW_POSIX_ERROR_CODE(errorcode, ...)           \
+  r_throw_posix_error(__func__, __FILE__, __LINE__, errorcode, NULL, __VA_ARGS__)
+
+
 #else
 
 #define R_THROW_SYSTEM_ERROR(...) \

--- a/src/processx-connection.c
+++ b/src/processx-connection.c
@@ -292,7 +292,7 @@ SEXP processx__connection_set_std(SEXP con, int which, int drop) {
     int saved = _dup(which);
     processx_file_handle_t os_handle;
     if (saved == -1) {
-      R_THROW_SYSTEM_ERROR("Cannot save stdout/stderr for rerouting");
+      R_THROW_POSIX_ERROR("Cannot save stdout/stderr for rerouting");
     }
     os_handle = (HANDLE) _get_osfhandle(saved) ;
     processx_c_connection_create(os_handle, PROCESSX_FILE_TYPE_PIPE,
@@ -301,7 +301,7 @@ SEXP processx__connection_set_std(SEXP con, int which, int drop) {
 
   fd = _open_osfhandle((intptr_t) ccon->handle.handle, 0);
   ret = _dup2(fd, which);
-  if (ret) R_THROW_SYSTEM_ERROR("Cannot reroute stdout/stderr");
+  if (ret) R_THROW_POSIX_ERROR("Cannot reroute stdout/stderr");
 
 #else
   const char *what[] = { "stdin", "stdout", "stderr" };


### PR DESCRIPTION
And fix `processx__connection_set_std()` error handling on Windows.