### PR TITLE
Use PKG_LIBS when linking client lib

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -20,7 +20,7 @@ supervisor/supervisor: supervisor/supervisor.c supervisor/utils.c
 CLIENT_OBJECTS = base64.o client.o errors.o
 
 client$(SHLIB_EXT): $(CLIENT_OBJECTS)
-	$(SHLIB_LINK) -o client$(SHLIB_EXT) $(CLIENT_OBJECTS)
+	$(SHLIB_LINK) -o client$(SHLIB_EXT) $(CLIENT_OBJECTS) $(PKG_LIBS)
 
 clean:
 	rm -rf $(SHLIB) $(OBJECTS) $(CLIENT_OBJECTS)		\

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -27,7 +27,7 @@ supervisor/supervisor.exe: supervisor/supervisor.c supervisor/utils.c \
 CLIENT_OBJECTS = base64.o client.o errors.o
 
 client$(SHLIB_EXT): $(CLIENT_OBJECTS)
-	$(SHLIB_LINK) -o client$(SHLIB_EXT) $(CLIENT_OBJECTS) $(LIBR) $(SHLIB_LIBADD)
+	$(SHLIB_LINK) -o client$(SHLIB_EXT) $(CLIENT_OBJECTS) $(LIBR) $(SHLIB_LIBADD) $(PKG_LIBS)
 
 clean:
 	rm -rf $(SHLIB) $(OBJECTS) $(CLIENT_OBJECTS)			\


### PR DESCRIPTION
So that we can override some flags and we can compile
a statically linked package.