### PR TITLE
Fix boot- & create-time issues on Linux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
   forward slashes: `//hostname/...` UNC paths with the usual
   back-slashes were always fine (#249).
 
+* The `$as_ps_handle()` method works now better; previously it
+  sometimes created an invalid `ps::ps_handle` object, if the system
+  clock has changed (#258).
+
 # processx 3.4.2
 
 * `run()` now does a better job with displaying the spinner on terminals

--- a/R/on-load.R
+++ b/R/on-load.R
@@ -2,8 +2,16 @@
 ## nocov start
 
 .onLoad <- function(libname, pkgname) {
-  ## This is to circumvent a ps bug
-  if (ps::ps_is_supported()) ps::ps_handle()
+  ## This is needed to fix the boot time to a given value,
+  ## because in a Docker container (maybe elsewhere as well?) on
+  ## Linux it can change (!).
+  ## See https://github.com/r-lib/processx/issues/258
+  if (ps::ps_is_supported()) {
+    ps::ps_handle()
+    bt <- ps::ps_boot_time()
+    .Call(c_processx__set_boot_time, bt)
+  }
+
   supervisor_reset()
   if (Sys.getenv("DEBUGME", "") != "" &&
       requireNamespace("debugme", quietly = TRUE)) {

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -159,15 +159,8 @@ void *processx__memmem(const void *haystack, size_t n1,
   return NULL;
 }
 
-static double processx__linux_boot_time = 0.0;
-
 double processx__boot_time() {
   return processx__linux_boot_time;
-}
-
-SEXP processx__set_boot_time(SEXP bt) {
-  processx__linux_boot_time = REAL(bt)[0];
-  return R_NilValue;
 }
 
 static double processx__linux_clock_period = 0.0;
@@ -194,6 +187,16 @@ double processx__create_time(long pid) {
 }
 
 #endif
+
+/* This is defined on all OSes, but only really needed (and used)
+ * on Linux. */
+
+static double processx__linux_boot_time = 0.0;
+
+SEXP processx__set_boot_time(SEXP bt) {
+  processx__linux_boot_time = REAL(bt)[0];
+  return R_NilValue;
+}
 
 #ifdef __APPLE__
 

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -39,6 +39,16 @@ double processx__create_time(HANDLE process) {
 
 #endif
 
+/* This is defined on all OSes, but only really needed (and used)
+ * on Linux. */
+
+static double processx__linux_boot_time = 0.0;
+
+SEXP processx__set_boot_time(SEXP bt) {
+  processx__linux_boot_time = REAL(bt)[0];
+  return R_NilValue;
+}
+
 #ifdef __linux__
 
 #include <sys/sysinfo.h>
@@ -187,16 +197,6 @@ double processx__create_time(long pid) {
 }
 
 #endif
-
-/* This is defined on all OSes, but only really needed (and used)
- * on Linux. */
-
-static double processx__linux_boot_time = 0.0;
-
-SEXP processx__set_boot_time(SEXP bt) {
-  processx__linux_boot_time = REAL(bt)[0];
-  return R_NilValue;
-}
 
 #ifdef __APPLE__
 

--- a/src/create-time.c
+++ b/src/create-time.c
@@ -159,26 +159,15 @@ void *processx__memmem(const void *haystack, size_t n1,
   return NULL;
 }
 
+static double processx__linux_boot_time = 0.0;
+
 double processx__boot_time() {
-  char *buf;
-  int ret;
-  const char *btime_str = "\nbtime ";
-  size_t btime_size = 7;
-  char *btime_pos;
-  unsigned long btime;
+  return processx__linux_boot_time;
+}
 
-  ret = processx__read_file("/proc/stat", &buf, /* buffer= */ 2048);
-  if (ret < 0)  return 0.0;
-
-  *(buf + ret - 1) = '\0';
-
-  btime_pos = processx__memmem(buf, ret, btime_str, btime_size);
-  if (! btime_pos) return 0.0;
-
-  ret = sscanf(btime_pos + btime_size, "%lu", &btime);
-  if (ret != 1) return 0.0;
-
-  return (double) btime;
+SEXP processx__set_boot_time(SEXP bt) {
+  processx__linux_boot_time = REAL(bt)[0];
+  return R_NilValue;
 }
 
 static double processx__linux_clock_period = 0.0;

--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,7 @@ SEXP processx__unload_cleanup();
 SEXP run_testthat_tests();
 SEXP processx__echo_on();
 SEXP processx__echo_off();
+SEXP processx__set_boot_time(SEXP);
 
 static const R_CallMethodDef callMethods[]  = {
   CLEANCALL_METHOD_RECORD,
@@ -31,6 +32,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_create_named_pipe",  (DL_FUNC) &processx_create_named_pipe,  2 },
   { "processx_write_named_pipe",   (DL_FUNC) &processx_write_named_pipe,   2 },
   { "processx__proc_start_time",   (DL_FUNC) &processx__proc_start_time,   1 },
+  { "processx__set_boot_time",     (DL_FUNC) &processx__set_boot_time,     1 },
 
   { "processx_connection_create",     (DL_FUNC) &processx_connection_create,     2 },
   { "processx_connection_read_chars", (DL_FUNC) &processx_connection_read_chars, 2 },


### PR DESCRIPTION
Apparently, on Linux the boot time in /proc (btime in /proc/stat)
is not fixed, but it can change if the system clock changes.
In Docker it also changes if the host machine goes to sleep and
then wakes up. This is a problem for us, because we use
(pid, start-time) as a process id, and the start-time depends
on the boot time. ps caches the boot time, but processx queried
it every time it needed it, and then it possibly ended up with
a different create-time than ps, and the $as_ps_handle() method
created a ps handle that did not actually work, because ps thought
that the process has finished already.

So now we query the boot time via ps in .onLoad(), and use that
for the current session. This way the ps and processx boot times
always match.

Closes #258.