### PR TITLE
[fix] #275

### DIFF
--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -43,9 +43,14 @@ void processx__create_connections(processx_handle_t *handle, SEXP private,
 #endif
 #endif
 
-#if defined(__APPLE__) && !TARGET_OS_IPHONE
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#if ! TARGET_OS_IPHONE
 # include <crt_externs.h>
 # define environ (*_NSGetEnviron())
+#else
+extern char **environ;
+#endif
 #else
 extern char **environ;
 #endif

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -44,13 +44,8 @@ void processx__create_connections(processx_handle_t *handle, SEXP private,
 #endif
 
 #if defined(__APPLE__)
-#include <TargetConditionals.h>
-#if ! TARGET_OS_IPHONE
 # include <crt_externs.h>
 # define environ (*_NSGetEnviron())
-#else
-extern char **environ;
-#endif
 #else
 extern char **environ;
 #endif


### PR DESCRIPTION
Be sure to `#include <TargetConditionals.h>` before using `TARGET_OS_IPHONE`, as seen [here](https://stackoverflow.com/a/11146573/435004)

Fixes #275