### PR TITLE
read buffer as bytes to handle UTF-8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # processx (development version)
 
-* Fix a string truncation in stdout and stderr of `run()` when output
-  contains multibyte characters.
+* `run()` now does not truncate stdout and stderr when the output
+  contains multibyte characters (#298, @infotroph).
 
 # processx 3.5.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # processx (development version)
 
-* Multibyte characters in stdout or stderr no longer cause truncation at
-  the end of the string.
+* Fix a string truncation in stdout and stderr of `run()` when output
+  contains multibyte characters.
 
 # processx 3.5.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # processx (development version)
 
+* Multibyte characters in stdout or stderr no longer cause truncation at
+  the end of the string.
+
 # processx 3.5.1
 
 * Fix a potential failure when polling curl file descriptors on Windows.

--- a/R/utils.R
+++ b/R/utils.R
@@ -256,7 +256,7 @@ make_buffer <- function() {
   size <- 0L
   list(
     push = function(text) {
-      size <<- size + nchar(text)
+      size <<- size + nchar(text, type = "bytes")
       cat(text, file = con)
     },
     read = function() {

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -79,4 +79,14 @@ test_that("native args are converted to UTF-8", {
   )
 })
 
-# TODO: UTF-8 output
+# TODO: more UTF-8 output
+
+test_that("UTF-8 in stdout", {
+  out <- run(get_tool("px"), c("out", "\u00fa\u00e1\u00f6"))
+  expect_equal(out$stdout, "\u00fa\u00e1\u00f6")
+})
+
+test_that("UTF-8 in stderr", {
+  out <- run(get_tool("px"), c("err", "\u00fa\u00e1\u00f6"))
+  expect_equal(out$stderr, "\u00fa\u00e1\u00f6")
+})


### PR DESCRIPTION
This appears to fix my examples of #298 and passes my quick stab at a test case, but I'm not confident it's The Correct Fix -- I don't know all the behaviors that need to be supported and have only checked it in one locale (en_US.UTF-8). Happy to refine this if needed.