### PR TITLE
Make sure SIGCHLD is handled by main thread

### DIFF
--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/signal.h>
+#include <pthread.h>
 
 # ifndef O_CLOEXEC
 #  define O_CLOEXEC 02000000
@@ -30,6 +31,7 @@ typedef struct processx_handle_s {
 char *processx__tmp_string(SEXP str, int i);
 char **processx__tmp_character(SEXP chr);
 
+extern pthread_t processx__main_thread;
 void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx);
 void processx__setup_sigchld();
 void processx__remove_sigchld();

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -50,6 +50,7 @@ extern char **environ;
 
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <pthread.h>
 
 extern processx__child_list_t child_list_head;
 extern processx__child_list_t *child_list;
@@ -63,6 +64,8 @@ extern int processx__notify_old_sigchld_handler;
    This function is called from `R_init_processx`. */
 
 void R_init_processx_unix() {
+  processx__main_thread = pthread_self();
+
   child_list_head.pid = 0;
   child_list_head.weak_status = R_NilValue;
   child_list_head.next = 0;


### PR DESCRIPTION
Otherwise we can get all kinds of issues. The return status of
the process might be NA (as in #308), there might be double frees,
crashes, freezes. Only comes out if a SIGCHLD arrives while
we are blocking it, and there is another thread that is willing
to handle it. So it is rare, but certainly possible.

Closes #308.