### PR TITLE
Require minimum of cli 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     utils
 Suggests:
     callr (>= 3.7.0),
-    cli,
+    cli (>= 1.1.0),
     codetools,
     covr,
     curl,


### PR DESCRIPTION
`col_red()` was added in cli 1.1.0

https://github.com/r-lib/processx/search?q=col_red
https://github.com/r-lib/cli/commit/bd86957597f76c720ce8ddc46b7ed377b2af2532
https://github.com/r-lib/cli/blob/main/NEWS.md#cli-110