### PR TITLE
Fix error tests when using non-English locale on Linux

### DIFF
--- a/tests/testthat/test-err.R
+++ b/tests/testthat/test-err.R
@@ -356,6 +356,7 @@ test_that("error is printed on error", {
     sf,
     stdout = so,
     stderr = se,
+    env = c(LC_ALL = "C"),
     fail_on_status = FALSE,
     show = FALSE
   )
@@ -386,6 +387,7 @@ test_that("trace is printed on error in non-interactive sessions", {
     sf,
     stdout = so,
     stderr = se,
+    env = c(LC_ALL = "C"),
     fail_on_status = FALSE,
     show = FALSE
   )


### PR DESCRIPTION
Two tests in `test-err.R` expect command output in English ([here](../blob/c1a84e2694463205c4a01fef4075fc02cd3ad530/tests/testthat/test-err.R#L365) and [here](../blob/c1a84e2694463205c4a01fef4075fc02cd3ad530/tests/testthat/test-err.R#L395)), but this message is localized on Linux systems and might be in a different language.

This patch passes the `LC_ALL=C` environment variable to the process which allows the tests to pass when using a non-English locale.