### PR TITLE
Windows interrupt fix if no console

### DIFF
--- a/src/tools/interrupt.c
+++ b/src/tools/interrupt.c
@@ -20,7 +20,7 @@ int main(int argc, const char **argv) {
 
   printf("Free console\n");
   bret = FreeConsole();
-  if (!bret) return GetLastError();
+  // This might fail if we have no console, and that is OK.
 
   printf("Attach console\n");
   bret = AttachConsole(pid);

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -97,16 +97,30 @@ test_that("stderr_to_stdout", {
 test_that("condition on interrupt", {
   skip_if_no_ps()
   skip_on_cran()
-  skip_on_appveyor() # TODO: why does this fail?
 
-  px <- get_tool("px")
-  cnd <- tryCatch(
-    interrupt_me(run(px, c("errln", "oops", "errflush", "sleep", 3)), 0.5),
-    error = function(c) c,
-    interrupt = function(c) c)
+  fun <- function(px) {
+    cnd <- tryCatch(
+      processx::run(px, c("errln", "oops", "errflush", "sleep", "3")),
+      error = function(x) x,
+      interrupt = function(x) x
+    )
+  }
+  proc <- callr::r_bg(fun, list(px = get_tool("px")))
+  start <- Sys.time()
+  proc$interrupt()
+  proc$wait(3000)
+  expect_true(Sys.time() < start + 3000)
 
-  expect_s3_class(cnd, "system_command_interrupt")
-  expect_equal(str_trim(cnd$stderr), "oops")
+  # We cannot handle the interrupt in a non-interactive session on Windows
+  # The exit code of the process will always be non-zero, at least in
+  # powershell.
+  if (.Platform$OS.type == "windows") {
+    expect_true(proc$get_exit_status() != 0)
+  } else{
+    cnd <- proc$get_result()
+    expect_s3_class(cnd, "system_command_interrupt")
+    expect_equal(str_trim(cnd$stderr), "oops")
+  }
 })
 
 test_that("stdin", {


### PR DESCRIPTION
Do not fail on `FreeConsole()` because the process
might not have a console, and that is completely fine.