### PR TITLE
avoid closing fd twice

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -207,8 +207,7 @@ SEXP processx_set_stdout_to_file(SEXP file) {
   if (fd == -1) {
     R_THROW_SYSTEM_ERROR("Cannot open new stdout file `%s`", c_file);
   }
-  SEXP ret = processx_set_std(1, fd, 0);
-  close(fd);
+  SEXP ret = processx_set_std(1, fd, 0); /* closes fd */
   return ret;
 }
 
@@ -222,8 +221,7 @@ SEXP processx_set_stderr_to_file(SEXP file) {
   if (fd == -1) {
     R_THROW_SYSTEM_ERROR("Cannot open new stderr file `%s`", c_file);
   }
-  SEXP ret = processx_set_std(2, fd, 0);
-  close(fd);
+  SEXP ret = processx_set_std(2, fd, 0); /* closes fd */
   return ret;
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -180,8 +180,6 @@ static SEXP processx_set_std(int which, int fd, int drop) {
     R_THROW_SYSTEM_ERROR("Cannot reroute %s", what[which]);
   }
 
-  close(fd);
-
   if (!drop) {
     return ScalarInteger(orig);
   } else {
@@ -207,7 +205,8 @@ SEXP processx_set_stdout_to_file(SEXP file) {
   if (fd == -1) {
     R_THROW_SYSTEM_ERROR("Cannot open new stdout file `%s`", c_file);
   }
-  SEXP ret = processx_set_std(1, fd, 0); /* closes fd */
+  SEXP ret = processx_set_std(1, fd, 0);
+  close(fd);
   return ret;
 }
 
@@ -221,7 +220,8 @@ SEXP processx_set_stderr_to_file(SEXP file) {
   if (fd == -1) {
     R_THROW_SYSTEM_ERROR("Cannot open new stderr file `%s`", c_file);
   }
-  SEXP ret = processx_set_std(2, fd, 0); /* closes fd */
+  SEXP ret = processx_set_std(2, fd, 0);
+  close(fd);
   return ret;
 }
 


### PR DESCRIPTION
This PR applies a patch from Tomas Kalibera, fixing an issue that might be seen using processx with R 4.2.0 on Windows (when the so-called "invalid parameter handler" is set to be invoked when invalid parameters are used).

Note, from https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/close?view=msvc-170:

> This function validates its parameters. If fd is a bad file descriptor, the invalid parameter handler is invoked, as described in [Parameter Validation](https://docs.microsoft.com/en-us/cpp/c-runtime-library/parameter-validation?view=msvc-170). If execution is allowed to continue, the functions returns -1 and errno is set to EBADF.

