### PR TITLE
Allow killing processes with `SIGTERM`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 3.8.0.9001
+Version: 3.8.0.9002
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-7098-9676")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Suggests:
     curl,
     debugme,
     parallel,
+    pkgload,
     rlang (>= 1.0.2),
     testthat (>= 3.0.0),
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: processx
 Title: Execute and Control System Processes
-Version: 3.8.0.9000
+Version: 3.8.0.9001
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-7098-9676")),
@@ -37,7 +37,7 @@ Suggests:
 Remotes:
     r-lib/callr@fix-client-so-name
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
 Config/Needs/website: tidyverse/tidytemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     R6,
     utils
 Suggests:
-    callr (>= 3.7.3.9001),
+    callr (>= 3.7.3),
     cli (>= 3.3.0),
     codetools,
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     R6,
     utils
 Suggests:
-    callr (>= 3.7.0),
+    callr (>= 3.7.3.9001),
     cli (>= 3.3.0),
     codetools,
     covr,
@@ -34,6 +34,8 @@ Suggests:
     rlang (>= 1.0.2),
     testthat (>= 3.0.0),
     withr
+Remotes:
+    r-lib/callr@fix-client-so-name
 Encoding: UTF-8
 RoxygenNote: 7.2.0
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # processx (development version)
 
-* The `kill_tree()` method gains a `signal` argument. This is useful
-  e.g. to gracefully terminate the process tree with `SIGTERM`.
+* The `kill()` and `kill_tree()` methods gain a `signal` argument.
+  This is useful to gracefully terminate processes, e.g. with
+  `SIGTERM`.
 
 * On Unixes, R processes created by callr now feature a `SIGTERM`
   cleanup handler that cleans up the temporary directory before

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # processx (development version)
 
+* On Unixes, R processes created by callr now feature a `SIGTERM`
+  cleanup handler that cleans up the temporary directory before
+  shutting down. To disable it, set the
+  `PROCESSX_NO_R_SIGTERM_CLEANUP` envvar to a non-empty value.
+
 # processx 3.8.0
 
 * processx error stacks are better now. They have ANSI hyperlinks for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # processx (development version)
 
+* The `kill_tree()` method gains a `signal` argument. This is useful
+  e.g. to gracefully terminate the process tree with `SIGTERM`.
+
 * On Unixes, R processes created by callr now feature a `SIGTERM`
   cleanup handler that cleans up the temporary directory before
   shutting down. To disable it, set the

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -27,12 +27,20 @@ on_failure(is_flag) <- function(call, env) {
   paste0(deparse(call$x), " is not a flag (length 1 logical)")
 }
 
+is_integer_scalar <- function(x) {
+  is.integer(x) && length(x) == 1 && !is.na(x) && round(x) == x
+}
+
+on_failure(is_integer_scalar) <- function(call, env) {
+  paste0(deparse(call$x), " is not a length 1 integer")
+}
+
 is_integerish_scalar <- function(x) {
   is.numeric(x) && length(x) == 1 && !is.na(x) && round(x) == x
 }
 
 on_failure(is_integerish_scalar) <- function(call, env) {
-  paste0(deparse(call$x), " is not a length 1 integer")
+  paste0(deparse(call$x), " is not a length 1 round number")
 }
 
 is_pid <- function(x) {

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -25,10 +25,10 @@
 process_initialize <- function(self, private, command, args,
                                stdin, stdout, stderr, pty, pty_options,
                                connections, poll_connection, env, cleanup,
-                               cleanup_tree, wd, echo_cmd, supervise,
-                               windows_verbatim_args, windows_hide_window,
-                               windows_detached_process, encoding,
-                               post_process) {
+                               cleanup_tree, cleanup_signal, wd, echo_cmd,
+                               supervise, windows_verbatim_args,
+                               windows_hide_window, windows_detached_process,
+                               encoding, post_process) {
 
   "!DEBUG process_initialize `command`"
 
@@ -45,6 +45,7 @@ process_initialize <- function(self, private, command, args,
     is.null(env) || is_env_vector(env),
     is_flag(cleanup),
     is_flag(cleanup_tree),
+    is_integer_scalar(cleanup_signal),
     is_string_or_null(wd),
     is_flag(echo_cmd),
     is_flag(windows_verbatim_args),
@@ -99,6 +100,7 @@ process_initialize <- function(self, private, command, args,
   private$args <- args
   private$cleanup <- cleanup
   private$cleanup_tree <- cleanup_tree
+  private$cleanup_signal <- cleanup_signal
   private$wd <- wd
   private$pstdin <- stdin
   private$pstdout <- stdout
@@ -139,8 +141,8 @@ process_initialize <- function(self, private, command, args,
     c_processx_exec,
     command, c(command, args), pty, pty_options,
     connections, env, windows_verbatim_args, windows_hide_window,
-    windows_detached_process, private, cleanup, wd, encoding,
-    paste0("PROCESSX_", private$tree_id, "=YES")
+    windows_detached_process, private, cleanup, cleanup_signal,
+    wd, encoding, paste0("PROCESSX_", private$tree_id, "=YES")
   )
 
   ## We try the query the start time according to the OS, because we can

--- a/R/process.R
+++ b/R/process.R
@@ -256,9 +256,11 @@ process <- R6::R6Class(
     #' `$kill_tree()` returns a named integer vector of the process ids that
     #' were killed, the names are the names of the processes (e.g. `"sleep"`,
     #' `"notepad.exe"`, `"Rterm.exe"`, etc.).
+    #' @param signal An integer scalar, the id of the signal to send to
+    #'   the process. See [tools::pskill()] for the list of signals.
 
-    kill_tree = function(grace = 0.1, close_connections = TRUE)
-      process_kill_tree(self, private, grace, close_connections),
+    kill_tree = function(grace = 0.1, close_connections = TRUE, signal = ps::signals()$SIGKILL)
+      process_kill_tree(self, private, grace, close_connections, signal),
 
     #' @description
     #' Send a signal to the process. On Windows only the
@@ -743,14 +745,15 @@ process_kill <- function(self, private, grace, close_connections) {
   ret
 }
 
-process_kill_tree <- function(self, private, grace, close_connections) {
-  "!DEBUG process_kill_tree '`private$get_short_name()`', pid `self$get_pid()`"
+process_kill_tree <- function(self, private, grace, close_connections, signal) {
+  "!DEBUG process_kill_tree '`private$get_short_name()`', pid `self$get_pid()`, signal `signal`"
   if (!ps::ps_is_supported()) {
     throw(new_not_implemented_error(
       "kill_tree is not supported on this platform"))
   }
+  assert_that(is_integer_scalar(signal))
 
-  ret <- get("ps_kill_tree", asNamespace("ps"))(private$tree_id)
+  ret <- get("ps_kill_tree", asNamespace("ps"))(private$tree_id, sig = signal)
   if (close_connections) private$close_connections()
   ret
 }

--- a/R/process.R
+++ b/R/process.R
@@ -748,7 +748,7 @@ process_kill <- function(self, private, grace, close_connections, signal) {
   "!DEBUG process_kill '`private$get_short_name()`', pid `self$get_pid()`"
   assert_that(is_integer_scalar(signal))
 
-  ret <- chain_call(c_processx_kill, private$status, as.numeric(grace),
+  ret <- chain_clean_call(c_processx_kill, private$status, as.numeric(grace),
                       private$get_short_name(), signal)
   if (close_connections) private$close_connections()
   ret

--- a/R/process.R
+++ b/R/process.R
@@ -240,9 +240,11 @@ process <- R6::R6Class(
     #' or job object (on Windows). It returns `TRUE` if the process
     #' was terminated, and `FALSE` if it was not (because it was
     #' already finished/dead when `processx` tried to terminate it).
+    #' @param signal An integer scalar, the id of the signal to send to
+    #'   the process. See [tools::pskill()] for the list of signals.
 
-    kill = function(grace = 0.1, close_connections = TRUE)
-      process_kill(self, private, grace, close_connections),
+    kill = function(grace = 0.1, close_connections = TRUE, signal = ps::signals()$SIGKILL)
+      process_kill(self, private, grace, close_connections, signal),
 
     #' @description
     #' Process tree cleanup. It terminates the process
@@ -737,10 +739,12 @@ process_interrupt <- function(self, private) {
   }
 }
 
-process_kill <- function(self, private, grace, close_connections) {
+process_kill <- function(self, private, grace, close_connections, signal) {
   "!DEBUG process_kill '`private$get_short_name()`', pid `self$get_pid()`"
+  assert_that(is_integer_scalar(signal))
+
   ret <- chain_call(c_processx_kill, private$status, as.numeric(grace),
-                      private$get_short_name())
+                      private$get_short_name(), signal)
   if (close_connections) private$close_connections()
   ret
 }

--- a/R/process.R
+++ b/R/process.R
@@ -184,6 +184,9 @@ process <- R6::R6Class(
     #'   object is garbage collected.
     #' @param cleanup_tree Whether to kill the process and its child
     #'   process tree when the `process` object is garbage collected.
+    #' @param cleanup_signal Which signal to use in case of cleanup.
+    #'   Defaults to `SIGKILL` but can be set to `tools::SIGTERM`.
+    #'   Has no effect on Windows.
     #' @param wd Working directory of the process. It must exist.
     #'   If `NULL`, then the current working directory is used.
     #' @param echo_cmd Whether to print the command to the screen before
@@ -210,19 +213,20 @@ process <- R6::R6Class(
     #'   It is only run once.
 
     initialize = function(command = NULL, args = character(),
-      stdin = NULL, stdout = NULL, stderr = NULL, pty = FALSE,
-      pty_options = list(), connections = list(), poll_connection = NULL,
-      env = NULL, cleanup = TRUE, cleanup_tree = FALSE, wd = NULL,
-      echo_cmd = FALSE, supervise = FALSE, windows_verbatim_args = FALSE,
-      windows_hide_window = FALSE, windows_detached_process = !cleanup,
-      encoding = "",  post_process = NULL)
+                          stdin = NULL, stdout = NULL, stderr = NULL, pty = FALSE,
+                          pty_options = list(), connections = list(), poll_connection = NULL,
+                          env = NULL, cleanup = TRUE, cleanup_tree = FALSE,
+                          cleanup_signal = ps::signals()$SIGKILL, wd = NULL,
+                          echo_cmd = FALSE, supervise = FALSE, windows_verbatim_args = FALSE,
+                          windows_hide_window = FALSE, windows_detached_process = !cleanup,
+                          encoding = "",  post_process = NULL)
 
       process_initialize(self, private, command, args, stdin,
-                         stdout, stderr, pty, pty_options, connections,
-                         poll_connection, env, cleanup, cleanup_tree, wd,
-                         echo_cmd, supervise, windows_verbatim_args,
-                         windows_hide_window, windows_detached_process,
-                         encoding, post_process),
+        stdout, stderr, pty, pty_options, connections,
+        poll_connection, env, cleanup, cleanup_tree,
+        cleanup_signal, wd, echo_cmd, supervise,
+        windows_verbatim_args, windows_hide_window,
+        windows_detached_process, encoding, post_process),
 
     #' @description
     #' Cleanup method that is called when the `process` object is garbage
@@ -231,7 +235,7 @@ process <- R6::R6Class(
 
     finalize = function() {
       if (!is.null(private$tree_id) && private$cleanup_tree &&
-          ps::ps_is_supported()) self$kill_tree()
+            ps::ps_is_supported()) self$kill_tree(signal = private$cleanup_signal)
     },
 
     #' @description
@@ -654,6 +658,7 @@ process <- R6::R6Class(
     args = NULL,          # Save 'args' argument here
     cleanup = NULL,       # cleanup argument
     cleanup_tree = NULL,  # cleanup_tree argument
+    cleanup_signal = NULL,# cleanup_signal argument
     stdin = NULL,         # stdin argument or stream
     stdout = NULL,        # stdout argument or stream
     stderr = NULL,        # stderr argument or stream

--- a/R/utils.R
+++ b/R/utils.R
@@ -306,3 +306,18 @@ rimraf <- function(...) {
   if ("~" %in% x) stop("Cowardly refusing to delete `~`")
   unlink(x, recursive = TRUE, force = TRUE)
 }
+
+get_test_lib <- function(lib) {
+  if (pkgload::is_dev_package("processx")) {
+    path <- "src"
+  } else {
+    path <- paste0('libs', .Platform$r_arch)
+  }
+
+  system.file(
+    package = "processx",
+    path,
+    "test",
+    paste0(lib, .Platform$dynlib.ext)
+  )
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -295,3 +295,14 @@ ends_with <- function(x, post) {
   l <- nchar(post)
   substr(x, nchar(x) - l + 1, nchar(x)) == post
 }
+
+defer <- function(expr, frame = parent.frame(), after = FALSE) {
+  thunk <- as.call(list(function() expr))
+  do.call(on.exit, list(thunk, add = TRUE, after = after), envir = frame)
+}
+
+rimraf <- function(...) {
+  x <- file.path(...)
+  if ("~" %in% x) stop("Cowardly refusing to delete `~`")
+  unlink(x, recursive = TRUE, force = TRUE)
+}

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -161,6 +161,7 @@ Start a new process in the background, and then return immediately.
   env = NULL,
   cleanup = TRUE,
   cleanup_tree = FALSE,
+  cleanup_signal = ps::signals()$SIGKILL,
   wd = NULL,
   echo_cmd = FALSE,
   supervise = FALSE,
@@ -274,6 +275,10 @@ object is garbage collected.}
 
 \item{\code{cleanup_tree}}{Whether to kill the process and its child
 process tree when the \code{process} object is garbage collected.}
+
+\item{\code{cleanup_signal}}{Which signal to use in case of cleanup.
+Defaults to \code{SIGKILL} but can be set to \code{tools::SIGTERM}.
+Has no effect on Windows.}
 
 \item{\code{wd}}{Working directory of the process. It must exist.
 If \code{NULL}, then the current working directory is used.}

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -366,7 +366,11 @@ to the root of the tree cleanup in the process tree any more.
 were killed, the names are the names of the processes (e.g. \code{"sleep"},
 \code{"notepad.exe"}, \code{"Rterm.exe"}, etc.).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{process$kill_tree(grace = 0.1, close_connections = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{process$kill_tree(
+  grace = 0.1,
+  close_connections = TRUE,
+  signal = tools::SIGKILL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -377,6 +381,9 @@ were killed, the names are the names of the processes (e.g. \code{"sleep"},
 \item{\code{close_connections}}{Whether to close standard input, standard
 output, standard error connections and the poll connection, after
 killing the process.}
+
+\item{\code{signal}}{An integer scalar, the id of the signal to send to
+the process. See \code{\link[tools:pskill]{tools::pskill()}} for the list of signals.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -335,7 +335,11 @@ or job object (on Windows). It returns \code{TRUE} if the process
 was terminated, and \code{FALSE} if it was not (because it was
 already finished/dead when \code{processx} tried to terminate it).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{process$kill(grace = 0.1, close_connections = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{process$kill(
+  grace = 0.1,
+  close_connections = TRUE,
+  signal = ps::signals()$SIGKILL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -346,6 +350,9 @@ already finished/dead when \code{processx} tried to terminate it).
 \item{\code{close_connections}}{Whether to close standard input, standard
 output, standard error connections and the poll connection, after
 killing the process.}
+
+\item{\code{signal}}{An integer scalar, the id of the signal to send to
+the process. See \code{\link[tools:pskill]{tools::pskill()}} for the list of signals.}
 }
 \if{html}{\out{</div>}}
 }
@@ -369,7 +376,7 @@ were killed, the names are the names of the processes (e.g. \code{"sleep"},
 \if{html}{\out{<div class="r">}}\preformatted{process$kill_tree(
   grace = 0.1,
   close_connections = TRUE,
-  signal = tools::SIGKILL
+  signal = ps::signals()$SIGKILL
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/process_initialize.Rd
+++ b/man/process_initialize.Rd
@@ -19,6 +19,7 @@ process_initialize(
   env,
   cleanup,
   cleanup_tree,
+  cleanup_signal,
   wd,
   echo_cmd,
   supervise,

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -25,6 +25,7 @@ run(
   windows_hide_window = FALSE,
   encoding = "",
   cleanup_tree = FALSE,
+  cleanup_signal = ps::signals()$SIGKILL,
   ...
 )
 }
@@ -127,6 +128,10 @@ both streams in UTF-8 currently.}
 
 \item{cleanup_tree}{Whether to clean up the child process tree after
 the process has finished.}
+
+\item{cleanup_signal}{Signal to cleanup the process (and its
+children if \code{cleanup_tree} is \code{TRUE}). Defaults to \code{SIGKILL}. On
+Windows, only \code{SIGTERM} and \code{SIGKILL} are supported.}
 
 \item{...}{Extra arguments are passed to \code{process$new()}, see
 \link{process}. Note that you cannot pass \code{stout} or \code{stderr} here,

--- a/src/Makevars
+++ b/src/Makevars
@@ -8,7 +8,8 @@ OBJECTS = init.o poll.o errors.o processx-connection.o   \
 
 .PHONY: all clean
 
-all: tools/px tools/sock supervisor/supervisor client$(SHLIB_EXT) $(SHLIB)
+all: tools/px tools/sock supervisor/supervisor client$(SHLIB_EXT) $(SHLIB) \
+     test/sigtermignore$(SHLIB_EXT)
 
 tools/px: tools/px.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -Wall tools/px.c -o tools/px
@@ -29,6 +30,9 @@ client$(SHLIB_EXT): $(CLIENT_OBJECTS)
 	    echo Removing libR.so dependency from client.so; \
 	    patchelf --remove-needed libR.so client$(SHLIB_EXT); \
 	fi
+
+test/sigtermignore$(SHLIB_EXT): test/sigtermignore.o
+	$(SHLIB_LINK) -o test/sigtermignore$(SHLIB_EXT) test/sigtermignore.o
 
 clean:
 	rm -rf $(SHLIB) $(OBJECTS) $(CLIENT_OBJECTS)		\

--- a/src/client.c
+++ b/src/client.c
@@ -249,7 +249,7 @@ void term_handler(int n) {
   // signal handler is not safe. To properly clean up a process, we'd
   // need R to handle SIGTERM and clean up at check-interrupt
   // time. We do run `atexit()` handlers though.
-  exit(EXIT_FAILURE);
+  exit(-SIGTERM);
 }
 
 void install_term_handler(void) {

--- a/src/client.c
+++ b/src/client.c
@@ -245,11 +245,8 @@ const char* rimraf_tmpdir_cmd = NULL;
 void term_handler(int n) {
   R_system(rimraf_tmpdir_cmd);
 
-  // We don't run finalization handlers because running R code from a
-  // signal handler is not safe. To properly clean up a process, we'd
-  // need R to handle SIGTERM and clean up at check-interrupt
-  // time. We do run `atexit()` handlers though.
-  exit(-SIGTERM);
+  // Continue signal
+  raise(SIGTERM);
 }
 
 void install_term_handler(void) {
@@ -286,6 +283,7 @@ void install_term_handler(void) {
 
   struct sigaction sig = {{ 0 }};
   sig.sa_handler = term_handler;
+  sig.sa_flags = SA_RESETHAND;
   sigaction(SIGTERM, &sig, NULL);
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -15,7 +15,7 @@ SEXP processx__set_boot_time(SEXP);
 
 static const R_CallMethodDef callMethods[]  = {
   CLEANCALL_METHOD_RECORD,
-  { "processx_exec",               (DL_FUNC) &processx_exec,              14 },
+  { "processx_exec",               (DL_FUNC) &processx_exec,              15 },
   { "processx_wait",               (DL_FUNC) &processx_wait,               3 },
   { "processx_is_alive",           (DL_FUNC) &processx_is_alive,           2 },
   { "processx_get_exit_status",    (DL_FUNC) &processx_get_exit_status,    2 },

--- a/src/init.c
+++ b/src/init.c
@@ -21,7 +21,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_get_exit_status",    (DL_FUNC) &processx_get_exit_status,    2 },
   { "processx_signal",             (DL_FUNC) &processx_signal,             3 },
   { "processx_interrupt",          (DL_FUNC) &processx_interrupt,          2 },
-  { "processx_kill",               (DL_FUNC) &processx_kill,               3 },
+  { "processx_kill",               (DL_FUNC) &processx_kill,               4 },
   { "processx_get_pid",            (DL_FUNC) &processx_get_pid,            1 },
   { "processx_create_time",        (DL_FUNC) &processx_create_time,        1 },
   { "processx_poll",               (DL_FUNC) &processx_poll,               3 },

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -18,3 +18,8 @@ file.copy(files, dest, overwrite = TRUE)
 if (file.exists("symbols.rds")) {
   file.copy("symbols.rds", dest, overwrite = TRUE)
 }
+
+test_files <- Sys.glob(paste0("test/*", SHLIB_EXT))
+test_dest <- file.path(dest, "test")
+dir.create(test_dest, recursive = TRUE, showWarnings = FALSE)
+file.copy(test_files, test_dest, overwrite = TRUE)

--- a/src/processx.h
+++ b/src/processx.h
@@ -45,8 +45,8 @@ extern "C" {
 SEXP processx_exec(SEXP command, SEXP args, SEXP pty, SEXP pty_options,
 		   SEXP connections, SEXP env, SEXP windows_verbatim_args,
 		   SEXP windows_hide_window, SEXP windows_detached_process,
-		   SEXP private_, SEXP cleanup, SEXP wd, SEXP encoding,
-		   SEXP tree_id);
+		   SEXP private_, SEXP cleanup, SEXP cleanup_signal,
+                   SEXP wd, SEXP encoding, SEXP tree_id);
 SEXP processx_wait(SEXP status, SEXP timeout, SEXP name);
 SEXP processx_is_alive(SEXP status, SEXP name);
 SEXP processx_get_exit_status(SEXP status, SEXP name);

--- a/src/processx.h
+++ b/src/processx.h
@@ -52,7 +52,7 @@ SEXP processx_is_alive(SEXP status, SEXP name);
 SEXP processx_get_exit_status(SEXP status, SEXP name);
 SEXP processx_signal(SEXP status, SEXP signal, SEXP name);
 SEXP processx_interrupt(SEXP status, SEXP name);
-SEXP processx_kill(SEXP status, SEXP grace, SEXP name);
+SEXP processx_kill(SEXP status, SEXP grace, SEXP name, SEXP signal);
 SEXP processx_get_pid(SEXP status);
 SEXP processx_create_time(SEXP r_pid);
 

--- a/src/test/sigtermignore.c
+++ b/src/test/sigtermignore.c
@@ -1,0 +1,11 @@
+#ifndef _WIN32
+
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+#include <signal.h>
+
+void R_init_sigtermignore(DllInfo *dll) {
+  signal(SIGTERM, SIG_IGN);
+}
+
+#endif

--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -23,6 +23,7 @@ typedef struct processx_handle_s {
   int fd2;			/* readable */
   int waitpipe[2];		/* use it for wait() with timeout */
   int cleanup;
+  int cleanup_signal;
   double create_time;
   processx_connection_t *pipes[3];
   int ptyfd;

--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -37,7 +37,11 @@ void processx__sigchld_callback(int sig, siginfo_t *info, void *ctx);
 void processx__setup_sigchld(void);
 void processx__remove_sigchld(void);
 void processx__block_sigchld(void);
+void processx__block_sigchld_save(sigset_t *old);
 void processx__unblock_sigchld(void);
+void processx__procmask_set(sigset_t *set);
+
+int c_processx_wait(processx_handle_t *handle, int timeout, const char *name);
 
 void processx__finalizer(SEXP status);
 

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -676,30 +676,38 @@ static void processx__wait_cleanup(void *ptr) {
 
 SEXP processx_wait(SEXP status, SEXP timeout, SEXP name) {
   processx_handle_t *handle = R_ExternalPtrAddr(status);
+  int ctimeout = INTEGER(timeout)[0];
   const char *cname = isNull(name) ? "???" : CHAR(STRING_ELT(name, 0));
-  int ctimeout = INTEGER(timeout)[0], timeleft = ctimeout;
+
+  int ret = c_processx_wait(handle, ctimeout, cname);
+  return ScalarLogical(ret);
+}
+
+int c_processx_wait(processx_handle_t *handle, int timeout, const char *name) {
   struct pollfd fd;
   int ret = 0;
   pid_t pid;
+  int timeleft = timeout;
 
   int *fds = malloc(sizeof(int) * 2);
   if (!fds) R_THROW_SYSTEM_ERROR("Allocating memory when waiting");
   fds[0] = fds[1] = -1;
   r_call_on_exit(processx__wait_cleanup, fds);
 
-  processx__block_sigchld();
+  sigset_t old;
+  processx__block_sigchld_save(&old);
 
   if (!handle) {
-    processx__unblock_sigchld();
-    return ScalarLogical(1);
+    processx__procmask_set(&old);
+    return 1;
   }
 
   pid = handle->pid;
 
   /* If we already have the status, then return now. */
   if (handle->collected) {
-    processx__unblock_sigchld();
-    return ScalarLogical(1);
+    processx__procmask_set(&old);
+    return 1;
   }
 
   /* Make sure this is active, in case another package replaced it... */
@@ -708,8 +716,8 @@ SEXP processx_wait(SEXP status, SEXP timeout, SEXP name) {
 
   /* Setup the self-pipe that we can poll */
   if (pipe(handle->waitpipe)) {
-    processx__unblock_sigchld();
-    R_THROW_SYSTEM_ERROR("processx error when waiting for '%s'", cname);
+    processx__procmask_set(&old);
+    R_THROW_SYSTEM_ERROR("processx error when waiting for '%s'", name);
   }
   fds[0] = handle->waitpipe[0];
   fds[1] = handle->waitpipe[1];
@@ -725,7 +733,7 @@ SEXP processx_wait(SEXP status, SEXP timeout, SEXP name) {
 
 
 
-  while (ctimeout < 0 || timeleft > PROCESSX_INTERRUPT_INTERVAL) {
+  while (timeout < 0 || timeleft > PROCESSX_INTERRUPT_INTERVAL) {
     do {
       ret = poll(&fd, 1, PROCESSX_INTERRUPT_INTERVAL);
     } while (ret == -1 && errno == EINTR);
@@ -745,7 +753,7 @@ SEXP processx_wait(SEXP status, SEXP timeout, SEXP name) {
       goto cleanup;
     }
 
-    if (ctimeout >= 0) timeleft -= PROCESSX_INTERRUPT_INTERVAL;
+    if (timeout >= 0) timeleft -= PROCESSX_INTERRUPT_INTERVAL;
   }
 
   /* Maybe we are not done, and there is a little left from the timeout */
@@ -757,7 +765,7 @@ SEXP processx_wait(SEXP status, SEXP timeout, SEXP name) {
 
   if (ret == -1) {
     R_THROW_SYSTEM_ERROR("processx wait with timeout error while "
-                         "waiting for '%s'", cname);
+                         "waiting for '%s'", name);
   }
 
  cleanup:
@@ -765,7 +773,9 @@ SEXP processx_wait(SEXP status, SEXP timeout, SEXP name) {
   handle->waitpipe[0] = -1;
   handle->waitpipe[1] = -1;
 
-  return ScalarLogical(ret != 0);
+  processx__procmask_set(&old);
+
+  return ret != 0;
 }
 
 /* This is similar to `processx_wait`, but a bit simpler, because we

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -962,7 +962,7 @@ SEXP processx_interrupt(SEXP status, SEXP name) {
  * still alive or not.
  */
 
-SEXP processx_kill(SEXP status, SEXP grace, SEXP name) {
+SEXP processx_kill(SEXP status, SEXP grace, SEXP name, SEXP signal) {
   processx_handle_t *handle = R_ExternalPtrAddr(status);
   const char *cname = isNull(name) ? "???" : CHAR(STRING_ELT(name, 0));
   pid_t pid;
@@ -997,8 +997,8 @@ SEXP processx_kill(SEXP status, SEXP grace, SEXP name) {
   /* If the process is not running, return (FALSE) */
   if (wp != 0) { goto cleanup; }
 
-  /* It is still running, so a SIGKILL */
-  int ret = kill(-pid, SIGKILL);
+  /* It is still running, so send the signal */
+  int ret = kill(-pid, INTEGER(signal)[0]);
   if (ret == -1 && (errno == ESRCH || errno == EPERM)) { goto cleanup; }
   if (ret == -1) {
     processx__unblock_sigchld();

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -1019,18 +1019,9 @@ SEXP processx_kill(SEXP status, SEXP grace, SEXP name, SEXP signal) {
     R_THROW_SYSTEM_ERROR("process_kill for '%s'", cname);
   }
 
-  /* Do a waitpid to collect the status and reap the zombie */
-  do {
-    wp = waitpid(pid, &wstat, 0);
-  } while (wp == -1 && errno == EINTR);
-
-  /* Collect exit status, and check if it was killed by a SIGKILL (or
-     the user-provided signal) If yes, this was most probably us
-     (although we cannot be sure in general...)
-     If the status was collected by another SIGCHLD, then the exit
-     status will be set to NA */
-  processx__collect_exit_status(status, wp, wstat);
-  result = handle->exitcode == -sig_num;
+  if (c_processx_wait(handle, 200, cname)) {
+    result = handle->exitcode == -sig_num;
+  }
 
  cleanup:
   processx__unblock_sigchld();

--- a/src/unix/sigchld.c
+++ b/src/unix/sigchld.c
@@ -128,13 +128,24 @@ void processx__remove_sigchld(void) {
   memset(&old_sig_handler, 0, sizeof(old_sig_handler));
 }
 
-void processx__block_sigchld(void) {
+void processx__block_sigchld_save(sigset_t *old) {
   sigset_t blockMask;
   sigemptyset(&blockMask);
   sigaddset(&blockMask, SIGCHLD);
-  if (sigprocmask(SIG_BLOCK, &blockMask, NULL) == -1) {
+
+  if (sigprocmask(SIG_BLOCK, &blockMask, old) == -1) {
     R_THROW_ERROR("processx error setting up signal handlers");
   }
+}
+
+void processx__procmask_set(sigset_t *set) {
+  if (sigprocmask(SIG_SETMASK, set, NULL) == -1) {
+    R_THROW_ERROR("processx error setting up signal handlers");
+  }
+}
+
+void processx__block_sigchld(void) {
+  processx__block_sigchld_save(NULL);
 }
 
 void processx__unblock_sigchld(void) {

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -1234,8 +1234,8 @@ SEXP processx_interrupt(SEXP status, SEXP name) {
   return R_NilValue;
 }
 
-SEXP processx_kill(SEXP status, SEXP grace, SEXP name) {
-  return processx_signal(status, ScalarInteger(9), name);
+SEXP processx_kill(SEXP status, SEXP grace, SEXP name, SEXP signal) {
+  return processx_signal(status, signal, name);
 }
 
 SEXP processx_get_pid(SEXP status) {

--- a/src/win/processx.c
+++ b/src/win/processx.c
@@ -866,10 +866,10 @@ void processx__handle_destroy(processx_handle_t *handle) {
 }
 
 SEXP processx_exec(SEXP command, SEXP args, SEXP pty, SEXP pty_options,
-		               SEXP connections, SEXP env, SEXP windows_verbatim_args,
+                   SEXP connections, SEXP env, SEXP windows_verbatim_args,
                    SEXP windows_hide, SEXP windows_detached_process,
-                   SEXP private, SEXP cleanup, SEXP wd, SEXP encoding,
-                   SEXP tree_id) {
+                   SEXP private, SEXP cleanup, SEXP cleanup_signal,
+                   SEXP wd, SEXP encoding, SEXP tree_id) {
 
   const char *ccommand = CHAR(STRING_ELT(command, 0));
   const char *cencoding = CHAR(STRING_ELT(encoding, 0));

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -151,3 +151,8 @@ scrub_srcref <- function(x) {
   x <- sub("\033[90m\033[39m", "", x, fixed = TRUE)
   x
 }
+
+load_sigtermignore <- function() {
+  lib <- asNamespace("processx")$get_test_lib("sigtermignore")
+  dyn.load(lib)
+}

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -64,7 +64,7 @@ test_that("is_integerish_scalar", {
     expect_false(is_integerish_scalar(n))
     expect_error(
       assert_that(is_integerish_scalar(n)),
-      "is not a length 1 integer"
+      "is not a length 1 round number"
     )
   }
 })

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -211,3 +211,15 @@ test_that("can use custom `cleanup_signal`", {
   # callr cleanup handler kicked in and deleted the tempdir
   expect_false(dir.exists(dir))
 })
+
+test_that("can load sigtermignore", {
+  p <- callr::r_session$new()
+  defer(p$kill())
+
+  p$run(load_sigtermignore)
+
+  tools::pskill(p$get_pid(), tools::SIGTERM)
+  tools::pskill(p$get_pid(), tools::SIGTERM)
+
+  expect_true(p$is_alive())
+})

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -69,6 +69,9 @@ test_that("working directory does not exist", {
 })
 
 test_that("R process is installed with a SIGTERM cleanup handler", {
+  # https://github.com/r-lib/callr/pull/250
+  skip_if_not_installed("callr", "3.7.3.9001")
+
   # Needs POSIX signal handling
   skip_on_os("windows")
 

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -223,3 +223,13 @@ test_that("can load sigtermignore", {
 
   expect_true(p$is_alive())
 })
+
+test_that("can kill with SIGTERM when ignored", {
+  p <- callr::r_session$new()
+  defer(p$kill())
+
+  p$run(load_sigtermignore)
+
+  expect_false(p$kill(close_connections = FALSE, signal = tools::SIGTERM))
+  expect_true(p$is_alive())
+})

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -112,6 +112,9 @@ test_that("R process is installed with a SIGTERM cleanup handler", {
 })
 
 test_that("can SIGTERM process", {
+  # https://github.com/r-lib/callr/pull/250
+  skip_if_not_installed("callr", "3.7.3.9001")
+
   # Write subprocess `tempdir()` to this file
   out <- tempfile()
   defer(rimraf(out))
@@ -136,6 +139,9 @@ test_that("can SIGTERM process", {
 })
 
 test_that("can SIGTERM process tree", {
+  # https://github.com/r-lib/callr/pull/250
+  skip_if_not_installed("callr", "3.7.3.9001")
+
   # Needs POSIX signals
   skip_on_os("windows")
 
@@ -175,6 +181,9 @@ test_that("can SIGTERM process tree", {
 })
 
 test_that("can use custom `cleanup_signal`", {
+  # https://github.com/r-lib/callr/pull/250
+  skip_if_not_installed("callr", "3.7.3.9001")
+
   # Should become the default in callr
   opts <- callr::r_process_options(extra = list(
     cleanup_signal = ps::signals()$SIGTERM

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -67,3 +67,43 @@ test_that("working directory does not exist", {
   ## This closes connections in finalizers
   gc()
 })
+
+test_that("R process is installed with a SIGTERM cleanup handler", {
+  # Needs POSIX signal handling
+  skip_on_os("windows")
+
+  out <- tempfile()
+
+  fn <- function(file) {
+    file.create(tempfile())
+    writeLines(tempdir(), file)
+  }
+
+  p <- callr::r_session$new()
+  p$run(fn, list(file = out))
+
+  p_temp_dir <- readLines(out)
+  expect_true(dir.exists(p_temp_dir))
+
+  p$signal(ps::signals()$SIGTERM)
+  p$wait()
+  expect_false(dir.exists(p_temp_dir))
+
+  # Disabled case
+  withr::local_envvar(c(PROCESSX_NO_R_SIGTERM_CLEANUP = "true"))
+
+  # Just in case R adds tempdir cleanup on SIGTERM
+  skip_on_cran()
+
+  p <- callr::r_session$new()
+  p$run(fn, list(file = out))
+
+  p_temp_dir <- readLines(out)
+  expect_true(dir.exists(p_temp_dir))
+
+  p$signal(ps::signals()$SIGTERM)
+  p$wait()
+
+  # Was not cleaned up
+  expect_true(dir.exists(p_temp_dir))
+})


### PR DESCRIPTION
Branched from #357

- Add `cleanup_signal` argument to `run()` and `process$new()`. This instructs processx to use softer termination on GC so that the callr cleanup handler may run.

- Add `signal` arguments to `kill()` and `kill_tree()` methods. Used internally to support the above, and externally by event loops.

- Since the kill signal may now be ignored by the process, poll for `SIGCHLD` with a timeout. This is implemented using `process_wait()` and tested with a new dynlib `sigtermignore` that installs a `SIGTERM` handler that ignores the signal.

I'm not 100% happy with the API implemented here. I can call `kill_tree(signal = SIGTERM)` in an event loop and register a subsequent `SIGKILL` with a delay, this part is fine. However, when processes created with `cleanup_signal = SIGTERM` fail to properly quit on GC, the processes might not be killed. Also it seems that `close_connections = TRUE` also causes the process to finish (e.g. it causes processes linked to sigtermignore to terminate), and I'm not sure how this interacts with SIGTERM cleanup.

Would it make sense to revive the `grace` argument and do staged termination with SIGTERM and SIGKILL by default?