### PR TITLE
Add support for `call = parent.frame()` pattern

### DIFF
--- a/R/standalone-errors.R
+++ b/R/standalone-errors.R
@@ -231,7 +231,10 @@ err <- local({
   #' @param frame The throwing context. Can be used to hide frames from
   #'   the backtrace.
 
-  throw <- throw_error <- function(cond, parent = NULL, frame = environment()) {
+  throw <- throw_error <- function(cond,
+                                   parent = NULL,
+                                   call = parent.frame(),
+                                   frame = environment()) {
     if (!inherits(cond, "condition")) {
       cond <- new_error(cond)
     }
@@ -240,7 +243,7 @@ err <- local({
     }
 
     if (isTRUE(cond[["call"]])) {
-      cond[["call"]] <- sys.call(-1) %||% sys.call()
+      cond[["call"]] <- frame_call(call)
     } else if (identical(cond[["call"]], FALSE)) {
       cond[["call"]] <- NULL
     } else if (is.environment(cond[["call"]])) {

--- a/R/standalone-errors.R
+++ b/R/standalone-errors.R
@@ -162,6 +162,10 @@
 # ### 3.1.3 -- 2023-01-15
 #
 # * Now we do not load packages when walking the trace.
+#
+# ### 3.1.4 -- 2023-04-13
+#
+# * `call.` can now be a frame environment as in `rlang::abort()`
 
 err <- local({
 
@@ -239,6 +243,8 @@ err <- local({
       cond[["call"]] <- sys.call(-1) %||% sys.call()
     } else if (identical(cond[["call"]], FALSE)) {
       cond[["call"]] <- NULL
+    } else if (is.environment(cond[["call"]])) {
+      cond[["call"]] <- frame_call(cond[["call"]])
     }
 
     cond <- process_call(cond)
@@ -1160,6 +1166,35 @@ err <- local({
     }
   }
 
+  frame_call <- function(frame) {
+    out <- NULL
+    delayedAssign("out", base::sys.call(), frame)
+    out
+  }
+
+  # Useful for snapshots so that they print without an unstable backtrace.
+  # Call `register_testthat_print()` before running tests.
+  testthat_print_error <- function(x, ...) {
+    x[["trace"]] <- NULL
+    x[["srcref"]] <- NULL
+    x[["procsrcref"]] <- NULL
+    attr(x[["call"]], "srcref") <- NULL
+    print(x)
+  }
+
+  registered <- FALSE
+  register_testthat_print <- function() {
+    if (!registered) {
+      registerS3method(
+        "testthat_print",
+        "rlib_error",
+        testthat_print_error,
+        asNamespace("testthat")
+      )
+      registered <<- TRUE
+    }
+  }
+
   # -- public API --------------------------------------------------------
 
   err_env <- environment()
@@ -1179,6 +1214,7 @@ err <- local({
       process_call     = process_call,
       onload_hook      = onload_hook,
       is_interactive   = is_interactive,
+      register_testthat_print = register_testthat_print,
       format = list(
         advice        = format_advice,
         call          = format_call,

--- a/tests/testthat/_snaps/standalone-errors.md
+++ b/tests/testthat/_snaps/standalone-errors.md
@@ -1,4 +1,19 @@
-# can pass frame as error call
+# can pass frame as error call in `new_error()`
+
+    Code
+      (expect_error(f()))
+    Output
+      <rlib_error_3_0/rlib_error/error>
+      Error in `f()`:
+      ! my message
+    Code
+      (expect_error(g()))
+    Output
+      <rlib_error_3_0/rlib_error/error>
+      Error in `g()`:
+      ! my message
+
+# can pass frame as error call in `throw()`
 
     Code
       (expect_error(f()))

--- a/tests/testthat/_snaps/standalone-errors.md
+++ b/tests/testthat/_snaps/standalone-errors.md
@@ -1,0 +1,15 @@
+# can pass frame as error call
+
+    Code
+      (expect_error(f()))
+    Output
+      <rlib_error_3_0/rlib_error/error>
+      Error in `f()`:
+      ! my message
+    Code
+      (expect_error(g()))
+    Output
+      <rlib_error_3_0/rlib_error/error>
+      Error in `g()`:
+      ! my message
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -151,3 +151,5 @@ scrub_srcref <- function(x) {
   x <- sub("\033[90m\033[39m", "", x, fixed = TRUE)
   x
 }
+
+err$register_testthat_print()

--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -350,3 +350,19 @@ test_that("trace is printed on error in non-interactive sessions", {
   )
   expect_true(any(grepl("Backtrace", selines)))
 })
+
+test_that("can pass frame as error call", {
+  check_bar <- function(call = parent.frame()) {
+    check_foo(call = call)
+  }
+  check_foo <- function(call = parent.frame()) {
+    throw(new_error("my message", call. = call))
+  }
+  f <- function() check_bar()
+  g <- function() check_foo()
+
+  expect_snapshot({
+    (expect_error(f()))
+    (expect_error(g()))
+  })
+})

--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -351,12 +351,28 @@ test_that("trace is printed on error in non-interactive sessions", {
   expect_true(any(grepl("Backtrace", selines)))
 })
 
-test_that("can pass frame as error call", {
+test_that("can pass frame as error call in `new_error()`", {
   check_bar <- function(call = parent.frame()) {
     check_foo(call = call)
   }
   check_foo <- function(call = parent.frame()) {
     throw(new_error("my message", call. = call))
+  }
+  f <- function() check_bar()
+  g <- function() check_foo()
+
+  expect_snapshot({
+    (expect_error(f()))
+    (expect_error(g()))
+  })
+})
+
+test_that("can pass frame as error call in `throw()`", {
+  check_bar <- function(call = parent.frame()) {
+    check_foo(call = call)
+  }
+  check_foo <- function(call = parent.frame()) {
+    throw(new_error("my message"), call = call)
   }
   f <- function() check_bar()
   g <- function() check_foo()


### PR DESCRIPTION
~Branched from #359~ Now rebased.