### PR TITLE
Parallel kill on session quit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ URL: https://processx.r-lib.org, https://github.com/r-lib/processx#readme
 BugReports: https://github.com/r-lib/processx/issues
 Depends: R (>= 3.4.0)
 Imports:
-    ps (>= 1.2.0),
+    ps (>= 1.7.5.9001),
     R6,
     utils
 Suggests:
@@ -36,6 +36,8 @@ Suggests:
     testthat (>= 3.0.0),
     webfakes,
     withr
+Remotes:
+    r-lib/ps@kill-tree-grace
 Encoding: UTF-8
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # processx (development version)
 
+* Processes are now killed in parallel with a period of grace on
+  garbage collection (if `cleanup_tree` is `TRUE`) and on session
+  quit. The delay can be controlled with the new `cleanup_grace`
+  argument.
+
 * The `grace` argument of the `kill()` method is now active on Unix
   platforms. processx first tries to kill with `SIGTERM` with a
   timeout of `grace` seconds. After the timeout, `SIGKILL` is sent as

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -1,4 +1,9 @@
 process_finalize <- function(private) {
+  ps <- process_cleanup_list(private)
+  ps::ps_kill_parallel(ps, private$cleanup_grace)
+}
+
+process_cleanup_list <- function(private) {
   ps <- list()
 
   if (private$cleanup) {
@@ -6,9 +11,34 @@ process_finalize <- function(private) {
     handle <- ps::ps_handle(private$pid, as.POSIXct(private$starttime))
     ps <- c(ps, list(handle))
   }
+
   if (private$cleanup_tree) {
     ps <- c(ps, ps::ps_find_tree(private$tree_id))
   }
 
-  ps::ps_kill_parallel(ps, private$cleanup_grace)
+  ps
 }
+
+session_finalize <- function(node) {
+  ps <- list()
+  grace <- 0
+
+  while (!node_is_root(node)) {
+    private <- wref_key(node_value(node))
+    ps <- c(ps, process_cleanup_list(private))
+
+    if (!is.null(private$cleanup_grace)) {
+      grace <- max(grace, private$cleanup_grace)
+    }
+
+    node <- node_next(node)
+  }
+
+  ps::ps_kill_parallel(ps, grace)
+}
+
+wref_key <- function(x) .Call(c_processx__wref_key, x)
+node_is_root <- function(x) is.null(node_next(x))
+node_prev <- function(x) x[[1]]
+node_next <- function(x) x[[2]]
+node_value <- function(x) x[[3]]

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -1,0 +1,14 @@
+process_finalize <- function(private) {
+  ps <- list()
+
+  if (private$cleanup) {
+    # Can't be created in advance because the ps finalizer might run first
+    handle <- ps::ps_handle(private$pid, as.POSIXct(private$starttime))
+    ps <- c(ps, list(handle))
+  }
+  if (private$cleanup_tree) {
+    ps <- c(ps, ps::ps_find_tree(private$tree_id))
+  }
+
+  ps::ps_kill_parallel(ps, private$cleanup_grace)
+}

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -141,7 +141,7 @@ process_initialize <- function(self, private, command, args,
     c_processx_exec,
     command, c(command, args), pty, pty_options,
     connections, env, windows_verbatim_args, windows_hide_window,
-    windows_detached_process, private, cleanup, cleanup_grace, wd, encoding,
+    windows_detached_process, private, cleanup, wd, encoding,
     paste0("PROCESSX_", private$tree_id, "=YES")
   )
 
@@ -154,6 +154,9 @@ process_initialize <- function(self, private, command, args,
   private$starttime <-
     chain_call(c_processx__proc_start_time, private$status)
   if (private$starttime == 0) private$starttime <- Sys.time()
+
+  # Needed for cleaning up
+  private$pid <- self$get_pid()
 
   ## Need to close this, otherwise the child's end of the pipe
   ## will not be closed when the child exits, and then we cannot

--- a/R/process.R
+++ b/R/process.R
@@ -233,11 +233,6 @@ process <- R6::R6Class(
     #' collected. If requested so in the process constructor, then it
     #' eliminates all processes in the process's subprocess tree.
 
-    finalize = function() {
-      if (!is.null(private$tree_id) && private$cleanup_tree &&
-          ps::ps_is_supported()) self$kill_tree(grace = private$cleanup_grace)
-    },
-
     #' @description
     #' Terminate the process. It also terminate all of its child
     #' processes, except if they have created a new process group (on Unix),
@@ -671,6 +666,7 @@ process <- R6::R6Class(
     windows_hide_window = NULL,
 
     status = NULL,        # C file handle
+    pid = NULL,           # pid for cleanup
 
     supervised = FALSE,   # Whether process is tracked by supervisor
 

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -91,7 +91,6 @@ p$is_alive()
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-process-new}{\code{process$new()}}
-\item \href{#method-process-finalize}{\code{process$finalize()}}
 \item \href{#method-process-kill}{\code{process$kill()}}
 \item \href{#method-process-kill_tree}{\code{process$kill_tree()}}
 \item \href{#method-process-signal}{\code{process$signal()}}
@@ -320,21 +319,14 @@ R6 object representing the process.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-process-finalize"></a>}}
-\if{latex}{\out{\hypertarget{method-process-finalize}{}}}
-\subsection{Method \code{finalize()}}{
-Cleanup method that is called when the \code{process} object is garbage
-collected. If requested so in the process constructor, then it
-eliminates all processes in the process's subprocess tree.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{process$finalize()}\if{html}{\out{</div>}}
-}
-
-}
-\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-process-kill"></a>}}
 \if{latex}{\out{\hypertarget{method-process-kill}{}}}
 \subsection{Method \code{kill()}}{
+Cleanup method that is called when the \code{process} object is garbage
+collected. If requested so in the process constructor, then it
+eliminates all processes in the process's subprocess tree.
+
+
 Terminate the process. It also terminate all of its child
 processes, except if they have created a new process group (on Unix),
 or job object (on Windows). It returns \code{TRUE} if the process

--- a/src/Makevars
+++ b/src/Makevars
@@ -4,7 +4,7 @@ OBJECTS = init.o poll.o errors.o processx-connection.o   \
           processx-vector.o create-time.o base64.o       \
 	  unix/childlist.o unix/connection.o             \
           unix/processx.o unix/sigchld.o unix/utils.o    \
-	  unix/named_pipe.o cleancall.o
+	  unix/named_pipe.o cleancall.o utils.o
 
 .PHONY: all clean
 

--- a/src/init.c
+++ b/src/init.c
@@ -15,7 +15,7 @@ SEXP processx__set_boot_time(SEXP);
 
 static const R_CallMethodDef callMethods[]  = {
   CLEANCALL_METHOD_RECORD,
-  { "processx_exec",               (DL_FUNC) &processx_exec,              15 },
+  { "processx_exec",               (DL_FUNC) &processx_exec,              14 },
   { "processx_wait",               (DL_FUNC) &processx_wait,               3 },
   { "processx_is_alive",           (DL_FUNC) &processx_is_alive,           2 },
   { "processx_get_exit_status",    (DL_FUNC) &processx_get_exit_status,    2 },

--- a/src/init.c
+++ b/src/init.c
@@ -12,6 +12,7 @@ SEXP run_testthat_tests(void);
 SEXP processx__echo_on(void);
 SEXP processx__echo_off(void);
 SEXP processx__set_boot_time(SEXP);
+SEXP processx__wref_key(SEXP);
 
 static const R_CallMethodDef callMethods[]  = {
   CLEANCALL_METHOD_RECORD,
@@ -33,6 +34,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "processx_write_named_pipe",   (DL_FUNC) &processx_write_named_pipe,   2 },
   { "processx__proc_start_time",   (DL_FUNC) &processx__proc_start_time,   1 },
   { "processx__set_boot_time",     (DL_FUNC) &processx__set_boot_time,     1 },
+  { "processx__wref_key",          (DL_FUNC) &processx__wref_key,          1 },
 
   { "processx_connection_create",     (DL_FUNC) &processx_connection_create,     2 },
   { "processx_connection_read_chars", (DL_FUNC) &processx_connection_read_chars, 2 },

--- a/src/processx.h
+++ b/src/processx.h
@@ -45,8 +45,8 @@ extern "C" {
 SEXP processx_exec(SEXP command, SEXP args, SEXP pty, SEXP pty_options,
 		   SEXP connections, SEXP env, SEXP windows_verbatim_args,
 		   SEXP windows_hide_window, SEXP windows_detached_process,
-		   SEXP private_, SEXP cleanup, SEXP cleanup_signal,
-                   SEXP wd, SEXP encoding, SEXP tree_id);
+		   SEXP private_, SEXP cleanup, SEXP wd, SEXP encoding,
+                   SEXP tree_id);
 SEXP processx_wait(SEXP status, SEXP timeout, SEXP name);
 SEXP processx_is_alive(SEXP status, SEXP name);
 SEXP processx_get_exit_status(SEXP status, SEXP name);
@@ -116,5 +116,11 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
+
+#define r_no_return __attribute__ ((noreturn))
+
+r_no_return void r_unwind(SEXP x);
+SEXP r_unwind_protect(void (*fn)(void *data), void *data);
+SEXP r_safe_eval(SEXP expr, SEXP env, SEXP *out);
 
 #endif

--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -23,8 +23,7 @@ typedef struct processx_handle_s {
   int fd2;			/* readable */
   int waitpipe[2];		/* use it for wait() with timeout */
   int cleanup;
-  int cleanup_signal;
-  double cleanup_grace;
+  SEXP r6_private;
   double create_time;
   processx_connection_t *pipes[3];
   int ptyfd;

--- a/src/unix/processx-unix.h
+++ b/src/unix/processx-unix.h
@@ -25,6 +25,7 @@ typedef struct processx_handle_s {
   int cleanup;
   SEXP r6_private;
   double create_time;
+  SEXP finalizer_node;
   processx_connection_t *pipes[3];
   int ptyfd;
 } processx_handle_t;

--- a/src/unix/processx.c
+++ b/src/unix/processx.c
@@ -21,7 +21,7 @@ static void processx__child_init(processx_handle_t *handle, SEXP connections,
                                  processx_options_t *options,
 				 const char *tree_id);
 
-static SEXP processx__make_handle(SEXP private, int cleanup, double cleanup_grace);
+static SEXP processx__make_handle(SEXP private, int cleanup);
 static void processx__handle_destroy(processx_handle_t *handle);
 void processx__create_connections(processx_handle_t *handle, SEXP private,
 				  const char *encoding);
@@ -336,6 +336,19 @@ SEXP c_processx_kill_data(void *payload) {
   return R_NilValue;
 }
 
+static
+SEXP finalizer_call(SEXP private) {
+  static SEXP finalize_fn = NULL;
+  if (!finalize_fn) {
+    finalize_fn = lang3(install(":::"),
+                        install("processx"),
+                        install("process_finalize"));
+    R_PreserveObject(finalize_fn);
+  }
+
+  return lang2(finalize_fn, private);
+}
+
 void processx__finalizer(SEXP status) {
   processx_handle_t *handle = (processx_handle_t*) R_ExternalPtrAddr(status);
 
@@ -348,15 +361,9 @@ void processx__finalizer(SEXP status) {
   if (!handle)
     return;
 
-  // FIXME: Do we need cleancall here?
-  if (handle->cleanup) {
-    struct cleanup_kill_data data = {
-      .status = status,
-      .grace = handle->cleanup_grace,
-      .name = R_NilValue
-    };
-    r_with_cleanup_context(c_processx_kill_data, &data);
-  }
+  SEXP call = PROTECT(finalizer_call(handle->r6_private));
+  SEXP err = r_safe_eval(call, R_BaseEnv, NULL);
+  UNPROTECT(1);
 
   /* Note: if no cleanup is requested, then we still have a sigchld
      handler, to read out the exit code via waitpid, but no handle
@@ -365,21 +372,25 @@ void processx__finalizer(SEXP status) {
   /* Deallocate memory */
   R_ClearExternalPtr(status);
   processx__handle_destroy(handle);
+
+  if (err) {
+    r_unwind(err);
+  }
 }
 
-static SEXP processx__make_handle(SEXP private, int cleanup, double cleanup_grace) {
+static SEXP processx__make_handle(SEXP private, int cleanup) {
   processx_handle_t * handle;
   SEXP result;
 
   handle = (processx_handle_t*) malloc(sizeof(processx_handle_t));
   if (!handle) { R_THROW_ERROR("Cannot make processx handle, out of memory"); }
   memset(handle, 0, sizeof(processx_handle_t));
+
   handle->waitpipe[0] = handle->waitpipe[1] = -1;
+  handle->r6_private = private;
 
   result = PROTECT(R_MakeExternalPtr(handle, private, R_NilValue));
   R_RegisterCFinalizerEx(result, processx__finalizer, 1);
-  handle->cleanup = cleanup;
-  handle->cleanup_grace = cleanup_grace;
 
   UNPROTECT(1);
   return result;
@@ -426,14 +437,12 @@ skip:
 SEXP processx_exec(SEXP command, SEXP args, SEXP pty, SEXP pty_options,
                    SEXP connections, SEXP env, SEXP windows_verbatim_args,
                    SEXP windows_hide_window, SEXP windows_detached_process,
-                   SEXP private, SEXP cleanup, SEXP cleanup_grace, SEXP wd,
-                   SEXP encoding, SEXP tree_id) {
+                   SEXP private, SEXP cleanup, SEXP wd, SEXP encoding,
+                   SEXP tree_id) {
 
   char *ccommand = processx__tmp_string(command, 0);
   char **cargs = processx__tmp_character(args);
   char **cenv = isNull(env) ? 0 : processx__tmp_character(env);
-  int ccleanup = INTEGER(cleanup)[0];
-  double ccleanup_grace = REAL(cleanup_grace)[0];
 
   const int cpty = LOGICAL(pty)[0];
   const char *cencoding = CHAR(STRING_ELT(encoding, 0));
@@ -468,7 +477,8 @@ SEXP processx_exec(SEXP command, SEXP args, SEXP pty, SEXP pty_options,
 
   processx__setup_sigchld();
 
-  result = PROTECT(processx__make_handle(private, ccleanup, ccleanup_grace));
+  int ccleanup = LOGICAL(cleanup)[0];
+  result = PROTECT(processx__make_handle(private, ccleanup));
   handle = R_ExternalPtrAddr(result);
 
   if (cpty) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -76,3 +76,7 @@ SEXP r_safe_eval(SEXP expr, SEXP env, SEXP *out) {
   struct safe_eval data = { .expr = expr, .env = env, .out = out };
   return r_unwind_protect(&safe_eval_callback, &data);
 }
+
+SEXP processx__wref_key(SEXP x) {
+  return R_WeakRefKey(x);
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,78 @@
+#include <Rinternals.h>
+#include "processx.h"
+
+// Need to jump out of the `R_UnwindProtect()` context
+#include <setjmp.h>
+
+r_no_return
+void r_unwind(SEXP x) {
+  if (inherits(x, "error")) {
+    SEXP call = PROTECT(lang2(install("stop"), x));
+    eval(call, R_BaseEnv);
+  } else {
+    R_ContinueUnwind(x);
+  }
+  error("Unreachable");
+}
+
+static
+void unwind_cleanup(void *payload, Rboolean jump) {
+  if (jump) {
+    jmp_buf *env = (jmp_buf *) payload;
+    longjmp(*env, 1);
+  }
+}
+
+// Conversion of SEXP-returning callback to a void-returning one
+struct callback_compat {
+  void (*fn)(void *data);
+  void *data;
+};
+
+static
+SEXP callback_compat(void *payload) {
+  struct callback_compat *data = (struct callback_compat *) payload;
+  data->fn(data->data);
+  return R_NilValue;
+}
+
+SEXP r_unwind_protect(void (*fn)(void *data), void *data) {
+  SEXP cont = PROTECT(R_MakeUnwindCont());
+  jmp_buf env;
+
+  struct callback_compat compat_data = {
+    .fn = fn,
+    .data = data
+  };
+
+  if (setjmp(env)) {
+    UNPROTECT(1);
+    return cont;
+  }
+
+  R_UnwindProtect(&callback_compat, &compat_data, &unwind_cleanup, &env, cont);
+
+  UNPROTECT(1);
+  return NULL;
+}
+
+struct safe_eval {
+  SEXP expr;
+  SEXP env;
+  SEXP *out;
+};
+
+static
+void safe_eval_callback(void *payload) {
+  struct safe_eval *data = (struct safe_eval *) payload;
+  SEXP out = eval(data->expr, data->env);
+
+  if (data->out) {
+    *data->out = out;
+  }
+}
+
+SEXP r_safe_eval(SEXP expr, SEXP env, SEXP *out) {
+  struct safe_eval data = { .expr = expr, .env = env, .out = out };
+  return r_unwind_protect(&safe_eval_callback, &data);
+}

--- a/src/win/processx-win.h
+++ b/src/win/processx-win.h
@@ -12,7 +12,7 @@ typedef struct processx_handle_s {
   BYTE *child_stdio_buffer;
   HANDLE waitObject;
   processx_connection_t *pipes[3];
-  int cleanup;
+  SEXP cleanup;
   double create_time;
 } processx_handle_t;
 


### PR DESCRIPTION
Branched from #367.

- Split process cleanup into GC-specific finalisers and a global session-quit finaliser. The session finaliser collects all living processes and optionally their trees, and uses the new `ps::ps_kill_parallel()` to kill them in parallel with a grace delay controlled by `cleanup_grace`.

- On creation, the cleanup info for the session finaliser is recorded in a doubly linked list that keeps track of living processes. It's doubly linked so that on GC of a process the node can be efficiently removed.