### PR TITLE
Make skip reason clearer

### DIFF
--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -134,7 +134,7 @@ test_that("chain_call", {
 })
 
 test_that("errors from subprocess", {
-  skip_if_not(isTRUE(tryCatch(packageVersion("callr") == "3.7.0", packageNotFoundError = function(c) FALSE)), "only with callr exactly 3.7.0")
+  skip_if_not(isTRUE(try(packageVersion("callr") == "3.7.0", silent = TRUE)), "only with callr exactly 3.7.0")
   err <- tryCatch(
     callr::r(function() 1 + "a"),
     error = function(e) e

--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -134,7 +134,7 @@ test_that("chain_call", {
 })
 
 test_that("errors from subprocess", {
-  if (!requireNamespace("callr", quietly = TRUE) || packageVersion("callr") != "3.7.0") skip("only with callr exactly 3.7.0")
+  skip_if(!requireNamespace("callr", quietly = TRUE) || packageVersion("callr") != "3.7.0", "only with callr exactly 3.7.0")
   err <- tryCatch(
     callr::r(function() 1 + "a"),
     error = function(e) e

--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -134,8 +134,7 @@ test_that("chain_call", {
 })
 
 test_that("errors from subprocess", {
-  skip_if_not_installed("callr", minimum_version = "3.7.0")
-  if (packageVersion("callr") != "3.7.0") skip("only with callr 3.7.0")
+  if (!requireNamespace("callr", quietly = TRUE) || packageVersion("callr") != "3.7.0") skip("only with callr exactly 3.7.0")
   err <- tryCatch(
     callr::r(function() 1 + "a"),
     error = function(e) e

--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -134,7 +134,7 @@ test_that("chain_call", {
 })
 
 test_that("errors from subprocess", {
-  skip_if(!requireNamespace("callr", quietly = TRUE) || packageVersion("callr") != "3.7.0", "only with callr exactly 3.7.0")
+  skip_if_not(isTRUE(tryCatch(packageVersion("callr") == "3.7.0", packageNotFoundError = function(c) FALSE)), "only with callr exactly 3.7.0")
   err <- tryCatch(
     callr::r(function() 1 + "a"),
     error = function(e) e


### PR DESCRIPTION
Glancing through my logs, I saw

```
11. errors from subprocess (test-standalone-errors.R:128:3) - Reason: only with callr 3.7.0
```

And thought "Oh, I need to update {callr}", but looking at the code, _exactly_ this version is what's needed. Hopefully this makes the skip reason more obvious.