### PR TITLE
Errors: store a call or NULL in cond$call

### DIFF
--- a/R/standalone-errors.R
+++ b/R/standalone-errors.R
@@ -903,9 +903,9 @@ err <- local({
 
   format_header_line_cli <- function(x, prefix = NULL) {
     p_error <- format_error_heading_cli(x, prefix)
-    p_call <- format_call_cli(x[["call"]])
-    p_srcref <- format_srcref_cli(conditionCall(x), x$procsrcref %||% x$srcref)
-    paste0(p_error, p_call, p_srcref, if (!is.null(conditionCall(x))) ":")
+    p_call <- format_call_cli(conditionCall(x))
+    p_srcref <- format_srcref_cli(p_call, x$procsrcref %||% x$srcref)
+    paste0(p_error, p_call, p_srcref, if (!is.null(p_call)) ":")
   }
 
   format_class_cli <- function(x) {
@@ -1006,9 +1006,9 @@ err <- local({
       ifelse(visible, "", "| "),
       scope,
       vapply(
-        seq_along(x$call),
+        seq_along(x[["call"]]),
         function(i) {
-          format_trace_call_cli(x$call[[i]], x$namespace[[i]])
+          format_trace_call_cli(x[["call"]][[i]], x$namespace[[i]])
         },
         character(1)
       ),
@@ -1115,7 +1115,7 @@ err <- local({
 
   format_header_line_plain <- function(x, prefix = NULL) {
     p_error <- format_error_heading_plain(x, prefix)
-    p_call <- format_call_plain(x[["call"]])
+    p_call <- format_call_plain(conditionCall(x))
     p_srcref <- format_srcref_plain(
       conditionCall(x),
       x$procsrcref %||% x$srcref
@@ -1189,15 +1189,17 @@ err <- local({
     nchar(x, type = "bytes")
   }
 
+  minimize_call <- function(call) {
+    if (!is.call(call)) return(call)
+    dep <- deparse(call, nlines = 2)
+    result <- tryCatch(str2lang(dep[[1L]]), error = function(e) NULL)
+    if (!is.null(result)) return(result)
+    tryCatch(as.call(list(call[[1L]], quote(...))), error = function(e) NULL)
+  }
+
   process_call <- function(cond) {
     cond[c("call", "srcref", "procsrcref")] <- list(
-      call = if (is.null(cond[["call"]])) {
-        NULL
-      } else if (is.character(cond[["call"]])) {
-        cond[["call"]]
-      } else {
-        deparse(cond[["call"]], nlines = 2)
-      },
+      call = minimize_call(cond[["call"]]),
       srcref = NULL,
       procsrcref = get_srcref(cond[["call"]], cond$procsrcref %||% cond$srcref)
     )
@@ -1301,9 +1303,13 @@ err <- local({
   }
 
   frame_call <- function(frame) {
-    out <- NULL
-    delayedAssign("out", base::sys.call(), frame)
-    out
+    frames <- sys.frames()
+    for (i in seq_along(frames)) {
+      if (identical(frames[[i]], frame)) {
+        return(sys.call(i))
+      }
+    }
+    NULL
   }
 
   # Useful for snapshots so that they print without an unstable backtrace.

--- a/tests/testthat/_snaps/Darwin/process.md
+++ b/tests/testthat/_snaps/Darwin/process.md
@@ -3,9 +3,9 @@
     Code
       process$new(tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! cannot start processx process '<tempdir>/<tempfile>' (system error 2, No such file or directory) @unix/processx.c:651 (processx_exec)
 
 # working directory does not exist
@@ -13,8 +13,8 @@
     Code
       process$new(px, wd = tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! cannot start processx process '<path>/px' (system error 2, No such file or directory) @unix/processx.c:651 (processx_exec)
 

--- a/tests/testthat/_snaps/Darwin/run.md
+++ b/tests/testthat/_snaps/Darwin/run.md
@@ -3,8 +3,8 @@
     Code
       run(px, wd = tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! cannot start processx process '<path>/px' (system error 2, No such file or directory) @unix/processx.c:651 (processx_exec)
 

--- a/tests/testthat/_snaps/Darwin/unix-sockets.md
+++ b/tests/testthat/_snaps/Darwin/unix-sockets.md
@@ -3,7 +3,7 @@
     Code
       conn_read_chars(sock1)
     Condition
-      Error:
+      Error in `processx_conn_read_chars()`:
       ! ! Native call to `processx_connection_read_chars` failed
       Caused by error in `chain_call(c_processx_connection_read_chars, con, n)` at connections.R:302:<col>:
       ! Cannot read from processx connection (system error 57, Socket is not connected) @processx-connection.c:1891 (processx__connection_read)
@@ -13,21 +13,21 @@
     Code
       conn_create_unix_socket(sock)
     Condition
-      Error:
+      Error in `conn_create_unix_socket()`:
       ! ! Native call to `processx_connection_create_socket` failed
       Caused by error in `chain_call(c_processx_connection_create_socket, filename, encoding)` at connections.R:618:<col>:
       ! Server socket path too long: <tempdir>/<tempfile>
     Code
       conn_create_unix_socket("/dev/null")
     Condition
-      Error:
+      Error in `conn_create_unix_socket()`:
       ! ! Native call to `processx_connection_create_socket` failed
       Caused by error in `chain_call(c_processx_connection_create_socket, filename, encoding)` at connections.R:618:<col>:
       ! Cannot bind to socket (system error 48, Address already in use) @processx-connection.c:479 (processx_connection_create_socket)
     Code
       conn_connect_unix_socket("/dev/null")
     Condition
-      Error:
+      Error in `conn_connect_unix_socket()`:
       ! ! Native call to `processx_connection_connect_socket` failed
       Caused by error in `chain_call(c_processx_connection_connect_socket, filename, encoding)` at connections.R:640:<col>:
       ! Cannot connect to socket (system error 38, Socket operation on non-socket) @processx-connection.c:550 (processx_connection_connect_socket)

--- a/tests/testthat/_snaps/Linux/process.md
+++ b/tests/testthat/_snaps/Linux/process.md
@@ -3,9 +3,9 @@
     Code
       process$new(tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! cannot start processx process '<tempdir>/<tempfile>' (system error 2, No such file or directory) @unix/processx.c:651 (processx_exec)
 
 # working directory does not exist
@@ -13,8 +13,8 @@
     Code
       process$new(px, wd = tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! cannot start processx process '<path>/px' (system error 2, No such file or directory) @unix/processx.c:651 (processx_exec)
 

--- a/tests/testthat/_snaps/Linux/run.md
+++ b/tests/testthat/_snaps/Linux/run.md
@@ -3,8 +3,8 @@
     Code
       run(px, wd = tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! cannot start processx process '<path>/px' (system error 2, No such file or directory) @unix/processx.c:651 (processx_exec)
 

--- a/tests/testthat/_snaps/Linux/unix-sockets.md
+++ b/tests/testthat/_snaps/Linux/unix-sockets.md
@@ -3,7 +3,7 @@
     Code
       conn_read_chars(sock1)
     Condition
-      Error:
+      Error in `processx_conn_read_chars()`:
       ! ! Native call to `processx_connection_read_chars` failed
       Caused by error in `chain_call(c_processx_connection_read_chars, con, n)` at connections.R:302:<col>:
       ! Cannot read from processx connection (system error 22, Invalid argument) @processx-connection.c:1891 (processx__connection_read)
@@ -13,21 +13,21 @@
     Code
       conn_create_unix_socket(sock)
     Condition
-      Error:
+      Error in `conn_create_unix_socket()`:
       ! ! Native call to `processx_connection_create_socket` failed
       Caused by error in `chain_call(c_processx_connection_create_socket, filename, encoding)` at connections.R:618:<col>:
       ! Server socket path too long: <tempdir>/<tempfile>
     Code
       conn_create_unix_socket("/dev/null")
     Condition
-      Error:
+      Error in `conn_create_unix_socket()`:
       ! ! Native call to `processx_connection_create_socket` failed
       Caused by error in `chain_call(c_processx_connection_create_socket, filename, encoding)` at connections.R:618:<col>:
       ! Cannot bind to socket (system error 98, Address already in use) @processx-connection.c:479 (processx_connection_create_socket)
     Code
       conn_connect_unix_socket("/dev/null")
     Condition
-      Error:
+      Error in `conn_connect_unix_socket()`:
       ! ! Native call to `processx_connection_connect_socket` failed
       Caused by error in `chain_call(c_processx_connection_connect_socket, filename, encoding)` at connections.R:640:<col>:
       ! Cannot connect to socket (system error 111, Connection refused) @processx-connection.c:550 (processx_connection_connect_socket)

--- a/tests/testthat/_snaps/Windows/process.md
+++ b/tests/testthat/_snaps/Windows/process.md
@@ -3,9 +3,9 @@
     Code
       process$new(tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! Command '<tempdir>/<tempfile>' not found @win/processx.c:1059 (processx_exec)
 
 # working directory does not exist
@@ -13,9 +13,9 @@
     Code
       process$new(px, wd = tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! create process '<path>/px' (system error 267, The directory name is invalid.
       ) @win/processx.c:1370 (processx_exec)
 

--- a/tests/testthat/_snaps/Windows/run.md
+++ b/tests/testthat/_snaps/Windows/run.md
@@ -3,9 +3,9 @@
     Code
       run(px, wd = tempfile())
     Condition
-      Error:
+      Error in `process_initialize()`:
       ! ! Native call to `processx_exec` failed
-      Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...` at initialize.R:<line>:<col>:
+      Caused by error in `chain_call(...)` at initialize.R:<line>:<col>:
       ! create process '<path>/px' (system error 267, The directory name is invalid.
       ) @win/processx.c:1370 (processx_exec)
 

--- a/tests/testthat/_snaps/Windows/unix-sockets.md
+++ b/tests/testthat/_snaps/Windows/unix-sockets.md
@@ -3,7 +3,7 @@
     Code
       conn_read_chars(sock1)
     Condition
-      Error:
+      Error in `processx_conn_read_chars()`:
       ! ! Native call to `processx_connection_read_chars` failed
       Caused by error in `chain_call(c_processx_connection_read_chars, con, n)` at connections.R:302:<col>:
       ! Cannot read from an un-accepted socket connection @processx-connection.c:1780 (processx__connection_read)

--- a/tests/testthat/_snaps/err-output.md
+++ b/tests/testthat/_snaps/err-output.md
@@ -72,10 +72,10 @@
        7. global h() at script.R:13:10
        8. global do() at script.R:14:10
        9. processx:::chain_error(do2(), "Failed to base64 encode") at script.R:10:9
-      10. | base::withCallingHandlers({
+      10. | base::withCallingHandlers(...)
       11. global do2()
       12. processx:::chain_error(do3(), "something is wrong here") at script.R:7:9
-      13. | base::withCallingHandlers({
+      13. | base::withCallingHandlers(...)
       14. global do3()
       15. processx:::throw("because of this") at script.R:4:9
       16. | base::signalCondition(cond)
@@ -121,10 +121,10 @@
        7. global h() at script.R:15:14
        8. global do() at script.R:16:14
        9. processx:::chain_error(do2(), "Failed to base64 encode") at script.R:12:13
-      10. | base::withCallingHandlers({ ...
+      10. | base::withCallingHandlers(...)
       11. global do2()
       12. processx:::chain_error(do3(), "something is wrong here") at script.R:9:13
-      13. | base::withCallingHandlers({ ...
+      13. | base::withCallingHandlers(...)
       14. global do3()
       15. processx:::throw("because of this") at script.R:6:13
       16. | base::signalCondition(cond)
@@ -157,13 +157,13 @@
        7. global h() at script.R:12:10
        8. global do() at script.R:13:10
        9. processx:::chain_error(do2(), "Failed to base64 encode") at script.R:9:9
-      10. | base::withCallingHandlers({
+      10. | base::withCallingHandlers(...)
       11. global do2()
       12. processx:::chain_error(do3(), "something is wrong here") at script.R:6:9
-      13. | base::withCallingHandlers({
+      13. | base::withCallingHandlers(...)
       14. global do3()
       15. base::stop("because of this") at script.R:3:9
-      16. | base::.handleSimpleError(function (e)
+      16. | base::.handleSimpleError(...)
       17. | local h(simpleError(msg, call))
       18. | processx:::throw_error(err, parent = e)
       19. | base::signalCondition(cond)
@@ -206,10 +206,10 @@
        7. global h() at script.R:13:10
        8. global do() at script.R:14:10
        9. processx:::chain_error(do2(), "Failed to base64 encode") at script.R:10:9
-      10. | base::withCallingHandlers({ ...
+      10. | base::withCallingHandlers(...)
       11. global do2()
       12. processx:::chain_error(do3(), "something is wrong here") at script.R:7:9
-      13. | base::withCallingHandlers({ ...
+      13. | base::withCallingHandlers(...)
       14. global do3()
       15. rlang::abort("because of this") at script.R:4:9
       16. | rlang:::signal_abort(cnd, .file)
@@ -253,9 +253,9 @@
        3. | base::eval(ei, envir)
        4. | base::eval(ei, envir)
        5. processx:::chain_error(processx::run(px, c("return", "1")), "failed to run  at script.R:4:5
-       6. | base::withCallingHandlers({
+       6. | base::withCallingHandlers(...)
        7. processx::run(px, c("return", "1"))
-       8. processx:::throw(new_process_error(res, call = sys.call(), echo = echo,
+       8. processx:::throw(...)
        9. | base::signalCondition(cond)
       10. | (function (e)
       11. | processx:::throw_error(err, parent = e)
@@ -291,9 +291,9 @@
        3. | base::eval(ei, envir)
        4. | base::eval(ei, envir)
        5. processx:::chain_error(processx::run(px, c("return", "1")), "failed to r... at script.R:6:9
-       6. | base::withCallingHandlers({ ...
+       6. | base::withCallingHandlers(...)
        7. processx::run(px, c("return", "1"))
-       8. processx:::throw(new_process_error(res, call = sys.call(), echo = echo, ...
+       8. processx:::throw(...)
        9. | base::signalCondition(cond)
       10. | (function (e) ...
       11. | processx:::throw_error(err, parent = e)

--- a/tests/testthat/_snaps/errors.md
+++ b/tests/testthat/_snaps/errors.md
@@ -3,7 +3,7 @@
     Code
       cat(out$stderr)
     Output
-      Error in `processx::run(processx:::get_tool("px"), c("errln", paste(1:20, ...` at script.R:2:5:
+      Error in `processx::run(...)` at script.R:2:5:
       ! System command 'px' failed
       ---
       Exit status: 100
@@ -34,7 +34,7 @@
       2. | base::withVisible(eval(ei, envir))
       3. | base::eval(ei, envir)
       4. | base::eval(ei, envir)
-      5. processx::run(processx:::get_tool("px"), c("errln", paste(1:20, at script.R:2:5
-      6. processx:::throw(new_process_error(res, call = sys.call(), echo = echo,
+      5. processx::run(...) at script.R:2:5
+      6. processx:::throw(...)
       Execution halted
 

--- a/tests/testthat/_snaps/fifo.md
+++ b/tests/testthat/_snaps/fifo.md
@@ -3,7 +3,7 @@
     Code
       conn_create_fifo(read = TRUE, write = TRUE)
     Condition
-      Error:
+      Error in `conn_create_fifo()`:
       ! ! Bi-directional FIFOs are not supported currently
 
 ---
@@ -11,6 +11,6 @@
     Code
       conn_connect_fifo(read = TRUE, write = TRUE)
     Condition
-      Error:
+      Error in `conn_connect_fifo()`:
       ! ! Bi-directional FIFOs are not supported currently
 

--- a/tests/testthat/_snaps/io.md
+++ b/tests/testthat/_snaps/io.md
@@ -3,32 +3,32 @@
     Code
       p$read_output_lines(n = 1)
     Condition
-      Error:
+      Error in `process_get_output_connection()`:
       ! ! stdout is not a pipe.
     Code
       p$read_all_output_lines()
     Condition
-      Error:
+      Error in `process_get_output_connection()`:
       ! ! stdout is not a pipe.
     Code
       p$read_all_output()
     Condition
-      Error:
+      Error in `process_get_output_connection()`:
       ! ! stdout is not a pipe.
     Code
       p$read_error_lines(n = 1)
     Condition
-      Error:
+      Error in `process_get_error_connection()`:
       ! ! stderr is not a pipe.
     Code
       p$read_all_error_lines()
     Condition
-      Error:
+      Error in `process_get_error_connection()`:
       ! ! stderr is not a pipe.
     Code
       p$read_all_error()
     Condition
-      Error:
+      Error in `process_get_error_connection()`:
       ! ! stderr is not a pipe.
 
 # same pipe
@@ -36,7 +36,7 @@
     Code
       p$read_all_error_lines()
     Condition
-      Error:
+      Error in `process_get_error_connection()`:
       ! ! stderr is not a pipe.
 
 # same file
@@ -44,7 +44,7 @@
     Code
       p$read_all_output_lines()
     Condition
-      Error:
+      Error in `process_get_output_connection()`:
       ! ! stdout is not a pipe.
 
 ---
@@ -52,7 +52,7 @@
     Code
       p$read_all_error_lines()
     Condition
-      Error:
+      Error in `process_get_error_connection()`:
       ! ! stderr is not a pipe.
 
 # same NULL, for completeness
@@ -60,7 +60,7 @@
     Code
       p$read_all_output_lines()
     Condition
-      Error:
+      Error in `process_get_output_connection()`:
       ! ! stdout is not a pipe.
 
 ---
@@ -68,6 +68,6 @@
     Code
       p$read_all_error_lines()
     Condition
-      Error:
+      Error in `process_get_error_connection()`:
       ! ! stderr is not a pipe.
 

--- a/tests/testthat/_snaps/newcli/err-output.md
+++ b/tests/testthat/_snaps/newcli/err-output.md
@@ -46,10 +46,10 @@
       [90m 7. [39mglobal [1mh[22m[38;5;178m()[39m[90m at script.R:18:14[39m
       [90m 8. [39mglobal [1mdo[22m[38;5;178m()[39m[90m at script.R:19:14[39m
       [90m 9. [39mprocessx:::[1mchain_error[22m[38;5;178m([39m[1mdo2[22m[33m()[39m, [38;5;37m"Failed to base64 encode"[38;5;178m)[39m[90m at script.R:15:13[39m
-      [90m10. | base::withCallingHandlers({ ...[39m
+      [90m10. | base::withCallingHandlers(...)[39m
       [90m11. [39mglobal [1mdo2[22m[38;5;178m()[39m
       [90m12. [39mprocessx:::[1mchain_error[22m[38;5;178m([39m[1mdo3[22m[33m()[39m, [38;5;37m"something is wrong here"[38;5;178m)[39m[90m at script.R:12:13[39m
-      [90m13. | base::withCallingHandlers({ ...[39m
+      [90m13. | base::withCallingHandlers(...)[39m
       [90m14. [39mglobal [1mdo3[22m[38;5;178m()[39m
       [90m15. [39mprocessx:::[1mthrow[22m[38;5;178m([38;5;37m"because of this"[38;5;178m)[39m[90m at script.R:9:13[39m
       [90m16. | base::signalCondition(cond)[39m
@@ -79,9 +79,9 @@
       [90m 3. | base::eval(ei, envir)[39m
       [90m 4. | base::eval(ei, envir)[39m
       [90m 5. [39mprocessx:::[1mchain_error[22m[38;5;178m([39mprocessx::[1mrun[22m[33m([39mpx, [1mc[22m[34m([39m[38;5;37m"return"[39m, [38;5;37m"1"[39m[34m)[39m[33m)[39m, [38;5;37m"failed to r[39m...[90m at script.R:9:9[39m
-      [90m 6. | base::withCallingHandlers({ ...[39m
+      [90m 6. | base::withCallingHandlers(...)[39m
       [90m 7. [39mprocessx::[1mrun[22m[38;5;178m([39mpx, [1mc[22m[33m([39m[38;5;37m"return"[39m, [38;5;37m"1"[39m[33m)[39m[38;5;178m)[39m
-      [90m 8. [39mprocessx:::throw(new_process_error(res, call = sys.call(), echo = echo, ...
+      [90m 8. [39mprocessx:::[1mthrow[22m[38;5;178m([39m...[38;5;178m)[39m
       [90m 9. | base::signalCondition(cond)[39m
       [90m10. | (function (e) ...[39m
       [90m11. | processx:::throw_error(err, parent = e)[39m

--- a/tests/testthat/_snaps/process.md
+++ b/tests/testthat/_snaps/process.md
@@ -3,6 +3,6 @@
     Code
       p$get_result()
     Condition
-      Error:
+      Error in `process_get_result()`:
       ! ! Process is still alive
 

--- a/tests/testthat/_snaps/pty.md
+++ b/tests/testthat/_snaps/pty.md
@@ -3,6 +3,6 @@
     Code
       p$read_output_lines()
     Condition
-      Error:
+      Error in `process_read_output_lines()`:
       ! ! Cannot read lines from a pty (see manual)
 

--- a/tests/testthat/_snaps/run.md
+++ b/tests/testthat/_snaps/run.md
@@ -3,7 +3,7 @@
     Code
       run(px, "out", encoding = "binary", stdout_line_callback = function(x, ...) x)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stdout_line_callback` cannot be used with `encoding = "binary"`
 
 ---
@@ -11,7 +11,7 @@
     Code
       run(px, "out", encoding = "binary", stderr_line_callback = function(x, ...) x)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stderr_line_callback` cannot be used with `encoding = "binary"`
 
 # pty=TRUE errors on incompatible arguments
@@ -19,7 +19,7 @@
     Code
       run("echo", pty = TRUE, stdout = NULL)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stdout` must be `"|"` (the default) if `pty = TRUE`
 
 ---
@@ -27,7 +27,7 @@
     Code
       run("echo", pty = TRUE, stderr = NULL)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stderr` must be `"|"` (the default) if `pty = TRUE`
 
 ---
@@ -35,7 +35,7 @@
     Code
       run("echo", pty = TRUE, stderr_to_stdout = TRUE)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stderr_to_stdout` must be `FALSE` if `pty = TRUE`
 
 ---
@@ -43,7 +43,7 @@
     Code
       run("echo", pty = TRUE, stderr_callback = function(x, ...) x)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stderr_callback` cannot be used with `pty = TRUE`
 
 ---
@@ -51,7 +51,7 @@
     Code
       run("echo", pty = TRUE, stderr_line_callback = function(x, ...) x)
     Condition
-      Error:
+      Error in `run()`:
       ! ! `stderr_line_callback` cannot be used with `pty = TRUE`
 
 ---
@@ -59,6 +59,6 @@
     Code
       run("echo", pty = TRUE, stdin = "|")
     Condition
-      Error:
+      Error in `run()`:
       ! ! When `pty = TRUE`, `stdin` must be `NULL` or a file path
 

--- a/tests/testthat/_snaps/standalone-errors.md
+++ b/tests/testthat/_snaps/standalone-errors.md
@@ -3,12 +3,12 @@
     Code
       f()
     Condition
-      Error:
+      Error in `f()`:
       ! ! my message
     Code
       g()
     Condition
-      Error:
+      Error in `g()`:
       ! ! my message
 
 # can pass frame as error call in `throw()`
@@ -16,11 +16,11 @@
     Code
       f()
     Condition
-      Error:
+      Error in `f()`:
       ! ! my message
     Code
       g()
     Condition
-      Error:
+      Error in `g()`:
       ! ! my message
 

--- a/tests/testthat/_snaps/unix-sockets.md
+++ b/tests/testthat/_snaps/unix-sockets.md
@@ -3,7 +3,7 @@
     Code
       conn_accept_unix_socket(sock1)
     Condition
-      Error:
+      Error in `conn_accept_unix_socket()`:
       ! ! Native call to `processx_connection_accept_socket` failed
       Caused by error in `chain_call(c_processx_connection_accept_socket, con)` at connections.R:653:<col>:
       ! Socket is not listening @processx-connection.c:577 (processx_connection_accept_socket)
@@ -13,7 +13,7 @@
     Code
       conn_write(sock1, "Hello\n")
     Condition
-      Error:
+      Error in `processx_conn_write()`:
       ! ! Native call to `processx_connection_write_bytes` failed
       Caused by error in `chain_call(c_processx_connection_write_bytes, con, str)` at connections.R:424:<col>:
       ! Cannot write to an un-accepted socket connection @processx-connection.c:1009 (processx_c_connection_write_bytes)
@@ -23,7 +23,7 @@
     Code
       conn_accept_unix_socket(ff)
     Condition
-      Error:
+      Error in `conn_accept_unix_socket()`:
       ! ! Native call to `processx_connection_accept_socket` failed
       Caused by error in `chain_call(c_processx_connection_accept_socket, con)` at connections.R:653:<col>:
       ! Not a socket connection @processx-connection.c:573 (processx_connection_accept_socket)
@@ -33,7 +33,7 @@
     Code
       conn_unix_socket_state(ff)
     Condition
-      Error:
+      Error in `conn_unix_socket_state()`:
       ! ! Native call to `processx_connection_socket_state` failed
       Caused by error in `chain_call(c_processx_connection_socket_state, con)` at connections.R:665:<col>:
       ! Not a socket connection @processx-connection.c:622 (processx_connection_socket_state)

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -3,16 +3,16 @@
     Code
       full_path("//")
     Condition
-      Error:
+      Error in `full_path()`:
       ! ! Server name not found in network path.
     Code
       full_path("///")
     Condition
-      Error:
+      Error in `full_path()`:
       ! ! Server name not found in network path.
     Code
       full_path("///a")
     Condition
-      Error:
+      Error in `full_path()`:
       ! ! Server name not found in network path.
 

--- a/tests/testthat/test-fifo.R
+++ b/tests/testthat/test-fifo.R
@@ -135,6 +135,7 @@ test_that("write end first 2", {
 
 test_that("errors", {
   skip_on_cran()
+  skip_if_no_srcrefs()
 
   expect_snapshot(error = TRUE, conn_create_fifo(read = TRUE, write = TRUE))
 

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -1,4 +1,5 @@
 test_that("Output and error are discarded by default", {
+  skip_if_no_srcrefs()
   px <- get_tool("px")
   p <- process$new(px, c("outln", "foobar"))
   on.exit(try_silently(p$kill(grace = 0)), add = TRUE)
@@ -203,6 +204,7 @@ test_that("readChar on IO, windows", {
 })
 
 test_that("same pipe", {
+  skip_if_no_srcrefs()
   px <- get_tool("px")
   cmd <- c("out", "o1", "err", "e1", "out", "o2", "err", "e2")
   p <- process$new(px, cmd, stdout = "|", stderr = "2>&1")
@@ -216,6 +218,7 @@ test_that("same pipe", {
 })
 
 test_that("same file", {
+  skip_if_no_srcrefs()
   px <- get_tool("px")
   cmd <- c("out", "o1", "err", "e1", "out", "o2", "errln", "e2")
   tmp <- tempfile()
@@ -231,6 +234,7 @@ test_that("same file", {
 })
 
 test_that("same NULL, for completeness", {
+  skip_if_no_srcrefs()
   px <- get_tool("px")
   cmd <- c("out", "o1", "err", "e1", "out", "o2", "errln", "e2")
   p <- process$new(px, cmd, stdout = NULL, stderr = "2>&1")

--- a/tests/testthat/test-pty.R
+++ b/tests/testthat/test-pty.R
@@ -11,7 +11,9 @@ test_that("pty works on windows", {
   out <- ""
   repeat {
     pr <- poll(list(con), 2000L)[[1]]
-    if (!identical(pr, "ready")) break
+    if (!identical(pr, "ready")) {
+      break
+    }
     out <- paste0(out, p$read_output())
     if (grepl("hello", out, fixed = TRUE)) break
   }
@@ -38,7 +40,9 @@ test_that("pty write_input works on windows", {
   out <- ""
   repeat {
     pr <- poll(list(con), 2000L)[[1]]
-    if (!identical(pr, "ready")) break
+    if (!identical(pr, "ready")) {
+      break
+    }
     out <- paste0(out, p$read_output())
     if (grepl("hello", out, fixed = TRUE)) break
   }
@@ -119,6 +123,7 @@ test_that("pty captures output from a short-lived process", {
 })
 
 test_that("read_output_lines() fails for pty", {
+  skip_if_no_srcrefs()
   skip_other_platforms("unix")
   skip_on_os("solaris")
   skip_on_cran()

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -229,6 +229,7 @@ test_that("binary=TRUE with stdout_callback receives raw chunks", {
 })
 
 test_that("binary=TRUE errors with line callbacks", {
+  skip_if_no_srcrefs()
   px <- get_tool("px")
   expect_snapshot(
     error = TRUE,
@@ -303,6 +304,7 @@ test_that("pty=TRUE works with stdout_callback (windows)", {
 })
 
 test_that("pty=TRUE errors on incompatible arguments", {
+  skip_if_no_srcrefs()
   skip_on_cran()
   expect_snapshot(error = TRUE, run("echo", pty = TRUE, stdout = NULL))
   expect_snapshot(error = TRUE, run("echo", pty = TRUE, stderr = NULL))

--- a/tests/testthat/test-standalone-errors.R
+++ b/tests/testthat/test-standalone-errors.R
@@ -66,7 +66,7 @@ test_that("throw() adds the proper call, if requested", {
   f <- function() throw(new_error("ooops"))
   err <- tryCatch(f(), error = function(e) e)
   expect_s3_class(err, "rlib_error")
-  expect_identical(err$call, "f()")
+  expect_identical(deparse(err$call), "f()")
 
   g <- function() throw(new_error("ooops", call. = FALSE))
   err <- tryCatch(g(), error = function(e) e)
@@ -130,7 +130,7 @@ test_that("chain_call", {
     error = function(e) e
   )
 
-  expect_equal(cond$call, "do()")
+  expect_equal(deparse(cond$call), "do()")
   expect_s3_class(cond, "c_error")
   expect_s3_class(cond, "rlib_error")
 })

--- a/tests/testthat/test-unix-sockets.R
+++ b/tests/testthat/test-unix-sockets.R
@@ -1,5 +1,6 @@
 test_that("CRUD", {
   skip_on_cran()
+  skip_if_no_srcrefs()
 
   sock <- tempfile()
   on.exit(unlink(sock), add = TRUE)


### PR DESCRIPTION
Three changes in `standalone-errors.R`:

1. Instead of storing the raw deparsed string in `$call`, re-parse it via `str2lang()` to produce a compact call object. For multiline calls that can't round-trip (e.g. `withCallingHandlers({...})`), the fallback is `f(...)` — the function head with `...` as the sole argument. This keeps `$call` always a proper call object or `NULL`, so `conditionCall()` and rlang work correctly without any custom S3 method. Because rlang does not use `conditionCall()`.

2. **`frame_call()`** — replace the fragile `delayedAssign()/sys.call()` trick with a straightforward search.

3. **Format functions** — use `conditionCall(x)` consistently instead of `x[["call"]]` directly, so the error header and trace formatting both go through the standard accessor.

Closes #360.